### PR TITLE
Filter functions and typedefs by prefix

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -2,15 +2,16 @@
 #include <clang/Tooling/CommonOptionsParser.h>
 
 
-static llvm::cl::OptionCategory Category("Binding Generator");
-static llvm::cl::extrahelp CommonHelp(clang::tooling::CommonOptionsParser::HelpMessage);
-static llvm::cl::extrahelp MoreHelp("\nProduce Bindings for scala native. Please specify lib name wit parameter name\n");
-static llvm::cl::opt<std::string> LibName("name", llvm::cl::cat(Category));
-static llvm::cl::opt<std::string> StdHeaders("stdHeaders", llvm::cl::cat(Category));
-static llvm::cl::opt<bool> PrintHeadersLocation ("location", llvm::cl::cat(Category));
-
-
 int main(int argc, char *argv[]) {
+    llvm::cl::OptionCategory Category("Binding Generator");
+    llvm::cl::extrahelp CommonHelp(clang::tooling::CommonOptionsParser::HelpMessage);
+    llvm::cl::extrahelp MoreHelp("\nProduce Bindings for scala native. Please specify lib name with parameter name\n");
+
+    llvm::cl::opt<std::string> LibName("name", llvm::cl::cat(Category));
+    llvm::cl::opt<std::string> StdHeaders("std-headers", llvm::cl::cat(Category));
+    llvm::cl::opt<bool> PrintHeadersLocation("location", llvm::cl::cat(Category));
+    llvm::cl::opt<std::string> ExcludePrefix("exclude-prefix", llvm::cl::cat(Category));
+    
     clang::tooling::CommonOptionsParser op(argc, (const char**)argv, Category);
     clang::tooling::ClangTool Tool(op.getCompilations(), op.getSourcePathList());
 
@@ -40,7 +41,7 @@ int main(int argc, char *argv[]) {
             llvm::outs() << location.c_str();
         }
     } else {
-        ir.generate();
+        ir.generate(ExcludePrefix.getValue());
         llvm::outs() << ir;
     }
     llvm::outs().flush();

--- a/Utils.h
+++ b/Utils.h
@@ -79,5 +79,23 @@ static inline void trim(std::string &s) {
     rtrim(s);
 }
 
+/**
+ * @return true if str starts with given prefix
+ */
+static inline bool startsWith(const std::string &str, const std::string &prefix) {
+    return str.substr(0, prefix.size()) == prefix;
+}
+
+/**
+ * @return true if checkedType uses type
+ *         example: checkedType = native.Ptr[struct_A], type = struct_A
+ */
+static inline bool typeUsesOtherType(const std::string &checkedType, const std::string &type) {
+    // TODO: find better way to check it
+    return checkedType == type ||
+           checkedType == "native.Ptr[" + type + "]" ||
+           startsWith(checkedType, "native.CArray[" + type + ", ");
+}
+
 
 #endif // UTILS_H

--- a/ir/Function.cpp
+++ b/ir/Function.cpp
@@ -30,3 +30,19 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Function &func) {
       << " = native.extern\n";
     return s;
 }
+
+bool Function::usesType(const std::string &type) const {
+    if (typeUsesOtherType(retType, type)) {
+        return true;
+    }
+    for (const auto &parameter : parameters) {
+        if (typeUsesOtherType(parameter.getType(), type)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::string Function::getName() const {
+    return name;
+}

--- a/ir/Function.h
+++ b/ir/Function.h
@@ -19,6 +19,10 @@ public:
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Function &func);
 
+    bool usesType(const std::string &type) const;
+
+    std::string getName() const;
+
 private:
     std::string name;
     std::vector<Parameter> parameters;

--- a/ir/IR.h
+++ b/ir/IR.h
@@ -35,7 +35,7 @@ public:
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const IR &ir);
 
-    void generate();
+    void generate(const std::string &excludePrefix);
 
 private:
 
@@ -48,6 +48,53 @@ private:
      * @return true if helper methods will be generated for this library
      */
     bool hasHelperMethods() const;
+
+    /**
+     * Remove functions that start with given prefix.
+     *
+     * Replace typedef by underlying type if it starts with given prefix
+     * and it is used only in other typedefs.
+     *
+     * Example:
+     * @code
+     * type __int32_t = native.CInt
+	 * type __darwin_pid_t = __int32_t
+	 * type pid_t = __darwin_pid_t
+     * @endcode
+     *
+     * Becomes:
+     * @code
+     * type pid_t = native.CInt
+     * @endcode
+     *
+     */
+    void filterDeclarations(const std::string &excludePrefix);
+
+    /**
+     * Remove all typedefs that start with given prefix.
+     */
+    void filterTypeDefs(const std::string &excludePrefix);
+
+    /**
+     * Find all typedefs that use oldType and replace it with newType.
+     */
+    void replaceTypeInTypeDefs(const std::string &oldType, const std::string &newType);
+
+    /**
+     * Remove functions with names that start with excludePrefix.
+     */
+    void filterFunctions(const std::string &excludePrefix);
+
+    /**
+     * @return true if given type is used only in typedefs.
+     */
+    bool typeIsUsedOnlyInTypeDefs(std::string type);
+
+    /**
+     * @return true if type is used in one of given declarations.
+     */
+    template<typename T>
+    bool isTypeUsed(const std::vector<T> &declarations, const std::string &type);
 
     std::string libName;
     std::vector<Function> functions;

--- a/ir/Struct.h
+++ b/ir/Struct.h
@@ -21,18 +21,29 @@ public:
 
     virtual std::string generateHelperClass() const = 0;
 
+    std::string getName() const;
+
+    virtual std::string getType() const = 0;
+
+    /**
+     * @return true if at leas one field has given type
+     */
+    bool usesType(const std::string &type) const;
+
 protected:
     std::string name; // names of structs and unions are not empty
     std::vector<Field> fields;
 };
 
-class Struct : StructOrUnion {
+class Struct : public StructOrUnion {
 public:
     Struct(std::string name, std::vector<Field> fields, uint64_t typeSize);
 
     TypeDef generateTypeDef() const override;
 
     std::string generateHelperClass() const override;
+
+    std::string getType() const override;
 
     /**
      * @return true if helper methods will be generated for this struct
@@ -46,13 +57,15 @@ private:
     uint64_t typeSize;
 };
 
-class Union : StructOrUnion {
+class Union : public StructOrUnion {
 public:
     Union(std::string name, std::vector<Field> members, uint64_t maxSize);
 
     TypeDef generateTypeDef() const override;
 
     std::string generateHelperClass() const override;
+
+    std::string getType() const override;
 
 private:
     uint64_t maxSize;

--- a/ir/TypeAndName.cpp
+++ b/ir/TypeAndName.cpp
@@ -10,3 +10,7 @@ std::string TypeAndName::getType() const {
 std::string TypeAndName::getName() const {
     return name;
 }
+
+void TypeAndName::setType(std::string type) {
+    this->type = std::move(type);
+}

--- a/ir/TypeAndName.h
+++ b/ir/TypeAndName.h
@@ -14,6 +14,8 @@ public:
 
     std::string getType() const;
 
+    void setType(std::string name);
+
     std::string getName() const;
 
 protected:

--- a/ir/TypeDef.cpp
+++ b/ir/TypeDef.cpp
@@ -8,3 +8,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const TypeDef &typeDef) {
     s << "  type " + handleReservedWords(typeDef.name) + " = " + typeDef.getType() + "\n";
     return s;
 }
+
+bool TypeDef::usesType(const std::string &type) const {
+    return typeUsesOtherType(this->type, type);
+}

--- a/ir/TypeDef.h
+++ b/ir/TypeDef.h
@@ -7,11 +7,13 @@
 #include <llvm/Support/raw_ostream.h>
 
 
-class TypeDef : TypeAndName {
+class TypeDef : public TypeAndName {
 public:
     TypeDef(std::string name, std::string type);
 
     friend llvm::raw_ostream &operator <<(llvm::raw_ostream &s, const TypeDef &type);
+
+    bool usesType(const std::string &type) const;
 };
 
 

--- a/tests/samples/PrivateMembers.h
+++ b/tests/samples/PrivateMembers.h
@@ -1,0 +1,49 @@
+typedef int __int32_t;
+typedef __int32_t __darwin_pid_t;
+typedef __darwin_pid_t pid_t; // should associate pid_t with int
+
+typedef int __private_type;
+
+struct structWithPrivateType {
+    int field1;
+    __private_type field2;
+}; // will not be removed
+
+union __unionWithPrivateName {
+    int a;
+}; // will not be removed
+
+struct structWithPrivateStruct {
+    struct structWithPrivateType *s;
+}; // will not be removed
+
+struct normalStruct {
+    int a;
+};
+
+enum __privateEnum {
+    A, B
+}; // will not be removed
+
+enum enumWithPrivateMembers {
+    __C, D
+}; // will not be removed
+
+enum {
+    __E, F
+}; // will not be removed
+
+typedef struct {
+    __private_type *a;
+} privateStructWithTypedef, *privateStructWithTypedefPtr; // will not be removed
+
+pid_t getTypeThatUsesPrivateTypes(); // will not be removed
+
+// functions that should be removed:
+void __privateFunction();
+
+// functions that should not be removed:
+__private_type *getPrivateType();
+void usesPrivateUnion(union __unionWithPrivateName);
+void usesPrivateStruct(struct structWithPrivateType *, struct normalStruct *);
+void usesPrivateEnum(enum __privateEnum *);

--- a/tests/samples/PrivateMembers.scala
+++ b/tests/samples/PrivateMembers.scala
@@ -1,0 +1,75 @@
+import scala.scalanative._
+import scala.scalanative.native._
+import scala.scalanative.native.Nat._
+
+@native.link("PrivateMembers")
+@native.extern
+object PrivateMembers {
+  type pid_t = native.CInt
+  type __private_type = native.CInt
+  type privateStructWithTypedef = struct_privateStructWithTypedef
+  type privateStructWithTypedefPtr = native.Ptr[struct_privateStructWithTypedef]
+  type enum___privateEnum = native.CUnsignedInt
+  type enum_enumWithPrivateMembers = native.CUnsignedInt
+  type struct_structWithPrivateType = native.CStruct2[native.CInt, __private_type]
+  type struct_structWithPrivateStruct = native.CStruct1[native.Ptr[struct_structWithPrivateType]]
+  type struct_normalStruct = native.CStruct1[native.CInt]
+  type struct_privateStructWithTypedef = native.CStruct1[native.Ptr[__private_type]]
+  type union___unionWithPrivateName = native.CArray[Byte, Digit[_3, _2]]
+  def getTypeThatUsesPrivateTypes(): pid_t = native.extern
+  def getPrivateType(): native.Ptr[__private_type] = native.extern
+  def usesPrivateUnion(anonymous0: union___unionWithPrivateName): Unit = native.extern
+  def usesPrivateStruct(anonymous0: native.Ptr[struct_structWithPrivateType], anonymous1: native.Ptr[struct_normalStruct]): Unit = native.extern
+  def usesPrivateEnum(anonymous0: native.Ptr[enum___privateEnum]): Unit = native.extern
+}
+
+import PrivateMembers._
+
+object PrivateMembersEnums {
+  final val enum___privateEnum_A: enum___privateEnum = 0.toUInt
+  final val enum___privateEnum_B: enum___privateEnum = 1.toUInt
+
+  final val enum_enumWithPrivateMembers___C: enum_enumWithPrivateMembers = 0.toUInt
+  final val enum_enumWithPrivateMembers_D: enum_enumWithPrivateMembers = 1.toUInt
+
+  final val enum___E: native.CUnsignedInt = 0.toUInt
+  final val enum_F: native.CUnsignedInt = 1.toUInt
+}
+
+object PrivateMembersHelpers {
+
+  implicit class struct_structWithPrivateType_ops(val p: native.Ptr[struct_structWithPrivateType]) extends AnyVal {
+    def field1: native.CInt = !p._1
+    def field1_=(value: native.CInt):Unit = !p._1 = value
+    def field2: __private_type = !p._2
+    def field2_=(value: __private_type):Unit = !p._2 = value
+  }
+
+  def struct_structWithPrivateType()(implicit z: native.Zone): native.Ptr[struct_structWithPrivateType] = native.alloc[struct_structWithPrivateType]
+
+  implicit class struct_structWithPrivateStruct_ops(val p: native.Ptr[struct_structWithPrivateStruct]) extends AnyVal {
+    def s: native.Ptr[struct_structWithPrivateType] = !p._1
+    def s_=(value: native.Ptr[struct_structWithPrivateType]):Unit = !p._1 = value
+  }
+
+  def struct_structWithPrivateStruct()(implicit z: native.Zone): native.Ptr[struct_structWithPrivateStruct] = native.alloc[struct_structWithPrivateStruct]
+
+  implicit class struct_normalStruct_ops(val p: native.Ptr[struct_normalStruct]) extends AnyVal {
+    def a: native.CInt = !p._1
+    def a_=(value: native.CInt):Unit = !p._1 = value
+  }
+
+  def struct_normalStruct()(implicit z: native.Zone): native.Ptr[struct_normalStruct] = native.alloc[struct_normalStruct]
+
+  implicit class struct_privateStructWithTypedef_ops(val p: native.Ptr[struct_privateStructWithTypedef]) extends AnyVal {
+    def a: native.Ptr[__private_type] = !p._1
+    def a_=(value: native.Ptr[__private_type]):Unit = !p._1 = value
+  }
+
+  def struct_privateStructWithTypedef()(implicit z: native.Zone): native.Ptr[struct_privateStructWithTypedef] = native.alloc[struct_privateStructWithTypedef]
+
+  implicit class union___unionWithPrivateName_pos(val p: native.Ptr[union___unionWithPrivateName]) extends AnyVal {
+    def a: native.Ptr[native.CInt] = p.cast[native.Ptr[native.CInt]]
+    def a_=(value: native.CInt): Unit = !p.cast[native.Ptr[native.CInt]] = value
+  }
+}

--- a/tests/src/test/scala/org/scalanative/bindgen/BindgenSpec.scala
+++ b/tests/src/test/scala/org/scalanative/bindgen/BindgenSpec.scala
@@ -22,8 +22,9 @@ class BindgenSpec extends FunSpec {
       val cmd = Seq(
         bindgenPath,
         inputFile.getAbsolutePath,
-        "-name",
+        "--name",
         name,
+        "--exclude-prefix=__",
         "--"
       )
       val output = Process(cmd).lineStream.mkString("\n")

--- a/visitor/TreeConsumer.h
+++ b/visitor/TreeConsumer.h
@@ -19,7 +19,7 @@ private:
 
 public:
 
-    explicit TreeConsumer(clang::CompilerInstance *CI, IR *ir)
+    TreeConsumer(clang::CompilerInstance *CI, IR *ir)
             : visitor(CI, ir),
               smanager(CI->getASTContext().getSourceManager()) {}
 


### PR DESCRIPTION
Add option `--exclude-prefix` that allows to specify prefix of declarations that should be excluded.

If chain of typedefs has aliases that should be excluded then this aliases are replaced by actual types:
```
type __int32_t = native.CInt
type __darwin_pid_t = __int32_t
type pid_t = __darwin_pid_t
``` 
=>
```
type pid_t = native.CInt
```
Also functions, structs, enums, union and typdefs are excluded if they use excluded types.

Issue #3 