### PR TITLE
Clean up encoding of natural numbers used in array sizes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(Clang REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
-add_compile_options(-fexceptions -std=c++11)
+add_compile_options(-fexceptions -std=c++11 -Wall -Wconversion -Werror)
 
 add_executable(bindgen
   Main.cpp

--- a/TypeTranslator.cpp
+++ b/TypeTranslator.cpp
@@ -116,8 +116,9 @@ std::string TypeTranslator::TranslateEnum(const clang::QualType& qtpe){
 }
 
 std::string TypeTranslator::TranslateConstantArray(const clang::ConstantArrayType* ar, const std::string* avoid){
-    const llvm::APInt& size =  ar->getSize();
-    return "native.CArray[" + Translate(ar->getElementType(), avoid) + ", " + intToScalaNat((int)size.roundToDouble()) + "]";
+    const uint64_t size = ar->getSize().getZExtValue();
+    const std::string nat = uint64ToScalaNat(size);
+    return "native.CArray[" + Translate(ar->getElementType(), avoid) + ", " + nat + "]";
 }
 
 std::string TypeTranslator::Translate(const clang::QualType& qtpe, const std::string* avoid){

--- a/Utils.h
+++ b/Utils.h
@@ -19,8 +19,8 @@ inline std::string uint64ToScalaNat(uint64_t v, std::string accumulator = "") {
     if (v == 0)
         return accumulator;
 
-    int last_digit = v % 10;
-    int rest = v / 10;
+    auto last_digit = v % 10;
+    auto rest = v / 10;
 
     if (accumulator.empty()) {
         return uint64ToScalaNat(rest, "_" + std::to_string(last_digit));
@@ -44,11 +44,11 @@ inline bool typeEquals(const clang::Type* tpe1, const std::string* tpe2){
     return false;
 }
 
-static std::array<std::string, 39> reserved_words = {"abstract", "case", "catch", "class", "def", "do", "else", "extends",
+static std::array<std::string, 39> reserved_words = {{"abstract", "case", "catch", "class", "def", "do", "else", "extends",
                                       "false", "final", "finally", "for", "forSome", "if", "implicit", "import",
                                       "lazy", "match", "new", "null", "object", "override", "package", "private",
                                       "protected", "return", "sealed", "super", "this", "throw", "trait", "try",
-                                      "true", "type", "val", "var", "while", "with", "yield"};
+                                      "true", "type", "val", "var", "while", "with", "yield"}};
 
 inline std::string handleReservedWords(std::string name, std::string suffix = "") {
     auto found = std::find(reserved_words.begin(), reserved_words.end(), name);

--- a/Utils.h
+++ b/Utils.h
@@ -15,35 +15,17 @@ inline std::string basename(const std::string& pathname) {
             pathname.end()};
 }
 
-inline std::string intToScalaNat(int v, std::string accumulator = ""){
-
-    if(v > 0){
-        int last_digit = v % 10;
-        int rest = v / 10;
-
-        if(accumulator == ""){
-            return intToScalaNat(rest, "_" + std::to_string(last_digit));
-        } else{
-            return intToScalaNat(rest, "Digit[_" + std::to_string(last_digit) + ", " + accumulator + "]");
-        }
-    } else{
+inline std::string uint64ToScalaNat(uint64_t v, std::string accumulator = "") {
+    if (v == 0)
         return accumulator;
-    }
-}
 
-inline std::string uint64ToScalaNat(uint64_t v, std::string accumulator = ""){
+    int last_digit = v % 10;
+    int rest = v / 10;
 
-    if(v > 0){
-        int last_digit = v % 10;
-        int rest = v / 10;
-
-        if(accumulator == ""){
-            return uint64ToScalaNat(rest, "_" + std::to_string(last_digit));
-        } else{
-            return uint64ToScalaNat(rest, "Digit[_" + std::to_string(last_digit) + ", " + accumulator + "]");
-        }
-    } else{
-        return accumulator;
+    if (accumulator.empty()) {
+        return uint64ToScalaNat(rest, "_" + std::to_string(last_digit));
+    } else {
+        return uint64ToScalaNat(rest, "Digit[_" + std::to_string(last_digit) + ", " + accumulator + "]");
     }
 }
 

--- a/ir/Function.cpp
+++ b/ir/Function.cpp
@@ -13,14 +13,13 @@ Function::Function(std::string name, std::vector<Parameter> parameters,
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Function &func) {
     s << "  def " << handleReservedWords(func.name)
       << "(";
-    for (std::vector<Parameter>::size_type i = 0; i < func.parameters.size(); i++) {
-        const Parameter &param = func.parameters[i];
-        s << handleReservedWords(param.getName())
+    std::string sep = "";
+    for (const auto &param : func.parameters) {
+        s << sep
+          << handleReservedWords(param.getName())
           << ": "
           << param.getType();
-        if (i + 1 != func.parameters.size()) {
-            s << ", ";
-        }
+        sep = ", ";
     }
     if (func.isVariadic) {
         /* the C Iso require at least one argument in a variadic function, so the comma is fine */

--- a/ir/Function.cpp
+++ b/ir/Function.cpp
@@ -13,13 +13,12 @@ Function::Function(std::string name, std::vector<Parameter> parameters,
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Function &func) {
     s << "  def " << handleReservedWords(func.name)
       << "(";
-    auto paramsCount = static_cast<int>(func.parameters.size());
-    for (int i = 0; i < paramsCount; ++i) {
+    for (std::vector<Parameter>::size_type i = 0; i < func.parameters.size(); i++) {
         const Parameter &param = func.parameters[i];
         s << handleReservedWords(param.getName())
           << ": "
           << param.getType();
-        if (i < paramsCount - 1) {
+        if (i + 1 != func.parameters.size()) {
             s << ", ";
         }
     }

--- a/ir/Struct.cpp
+++ b/ir/Struct.cpp
@@ -24,11 +24,10 @@ TypeDef Struct::generateTypeDef() const {
 
 std::string Struct::getFieldsTypes() const {
     std::stringstream s;
-    for (std::vector<Field>::size_type i = 0; i < fields.size(); i++) {
-        s << fields[i].getType();
-        if (i + 1 != fields.size()) {
-            s << ", ";
-        }
+    std::string sep = "";
+    for (const auto &field : fields) {
+        s << sep << field.getType();
+        sep = ", ";
     }
     return s.str();
 }

--- a/ir/Struct.cpp
+++ b/ir/Struct.cpp
@@ -24,10 +24,9 @@ TypeDef Struct::generateTypeDef() const {
 
 std::string Struct::getFieldsTypes() const {
     std::stringstream s;
-    auto fieldsCount = static_cast<int>(fields.size());
-    for (int i = 0; i < fieldsCount; i++) {
+    for (std::vector<Field>::size_type i = 0; i < fields.size(); i++) {
         s << fields[i].getType();
-        if (i < fieldsCount - 1) {
+        if (i + 1 != fields.size()) {
             s << ", ";
         }
     }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,8 +10,9 @@ if [[ ! -e target/.llvm-version ]] || [[ "$(<target/.llvm-version)" != "${LLVM_V
   mkdir -p target
   echo "${LLVM_VERSION:-}" > target/.llvm-version
   (cd target && cmake ..)
-  make -C target
 fi
+
+make -C target
 
 cd tests
 sbt "${@:-test}"

--- a/visitor/TreeConsumer.h
+++ b/visitor/TreeConsumer.h
@@ -17,15 +17,11 @@ private:
 
     clang::SourceManager &smanager;
 
-    /* pointer to ir that is stored in ScalaFrontendActionFactory */
-    IR *ir;
-
 public:
 
     explicit TreeConsumer(clang::CompilerInstance *CI, IR *ir)
             : visitor(CI, ir),
-              smanager(CI->getASTContext().getSourceManager()),
-              ir(ir) {}
+              smanager(CI->getASTContext().getSourceManager()) {}
 
     bool HandleTopLevelDecl(clang::DeclGroupRef DG) override {
         // a DeclGroupRef may have multiple Decls, so we iterate through each one

--- a/visitor/TreeVisitor.cpp
+++ b/visitor/TreeVisitor.cpp
@@ -109,8 +109,6 @@ void TreeVisitor::handleUnion(clang::RecordDecl *record, std::string name) {
         fields.push_back(Field(fname, ftype));
     }
 
-    auto usize = intToScalaNat(static_cast<int>(maxSize));
-
     ir->addUnion(name, fields, maxSize);
 }
 


### PR DESCRIPTION
Constant array sizes can only be positive so remove signed conversion
of integer to Scala Native natural number encoding in favour of the
unsigned one.

Refs #39