### PR TITLE
[WIP] Build static executable

### DIFF
--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.9)
 project(scala-native-bindgen)
 
+SET(USE_SHARED FALSE)
+SET(SHARED_LIBRARY FALSE)
+SET(LLVM_BUILD_LLVM_DYLIB FALSE)
+SET(LLVM_LINK_LLVM_DYLIB FALSE)
+SET(BUILD_SHARED_LIBS FALSE)
+
 # Locate $LLVM_PATH/lib/cmake/clang/ClangConfig.cmake
 find_package(Clang REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
@@ -40,13 +46,15 @@ add_executable(bindgen
   ir/TypeAndName.h
 )
 
+# llvm_config(bindgen)
+
 set_target_properties(bindgen
   PROPERTIES
   OUTPUT_NAME scala-native-bindgen
+  LINK_FLAGS "-static"
 )
 
 target_link_libraries(bindgen
   PRIVATE
-  clangFrontend
   clangTooling
 )


### PR DESCRIPTION
Closes #33 
Currently it fails with following message:
```
/usr/bin/ld: attempted static link of dynamic object `/usr/lib/llvm-4.0/lib/libLLVM-4.0.so.1'
collect2: error: ld returned 1 exit status
CMakeFiles/bindgen.dir/build.make:396: recipe for target 'scala-native-bindgen' failed
make[3]: *** [scala-native-bindgen] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/bindgen.dir/all' failed
make[2]: *** [CMakeFiles/bindgen.dir/all] Error 2
CMakeFiles/Makefile2:79: recipe for target 'CMakeFiles/bindgen.dir/rule' failed
make[1]: *** [CMakeFiles/bindgen.dir/rule] Error 2
```
I am not sure whether this dependency to libLLVM is mandatory. Seems like it is a collection of all static libraries (maybe not all of the libraries are included), and there is an options to avoid it. 

For example LLVM-Config.cmake has this line:
> If USE_SHARED is specified, then we link against libLLVM

But LLVM-Config.cmake is not imported by our CMakeLists.txt and `USE_SHARED` parameter has no effect.

I tried to add `llvm_config(bindgen)` line to CMakeLists.txt which executes the lines from LLVM-Config.cmake that use `USE_SHARED` but it did not lead to any changes.