### PR TITLE
Generate bindings for defines for variables

### DIFF
--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -48,6 +48,8 @@ add_executable(bindgen
   ir/Define.cpp
   ir/LiteralDefine.cpp
   ir/LiteralDefine.h
+  ir/VarDefine.cpp
+  ir/VarDefine.h
 )
 
 set_target_properties(bindgen

--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -50,6 +50,10 @@ add_executable(bindgen
   ir/LiteralDefine.h
   ir/VarDefine.cpp
   ir/VarDefine.h
+  ir/Variable.cpp
+  ir/Variable.h
+  ir/PossibleVarDefine.cpp
+  ir/PossibleVarDefine.h
 )
 
 set_target_properties(bindgen

--- a/bindgen/defines/DefineFinder.cpp
+++ b/bindgen/defines/DefineFinder.cpp
@@ -42,6 +42,11 @@ void DefineFinder::MacroDefined(const clang::Token &macroNameTok,
             std::string literal(stringToken.getLiteralData(),
                                 stringToken.getLength());
             ir.addLiteralDefine(macroName, "c" + literal, "native.CString");
+        } else if (tokens->size() == 1 &&
+                   (*tokens)[0].getKind() == clang::tok::identifier) {
+            // token might be a variable
+            std::string varName = (*tokens)[0].getIdentifierInfo()->getName();
+            ir.addPossibleVarDefine(macroName, varName);
         }
         std::free(tokens);
     }

--- a/bindgen/ir/Define.cpp
+++ b/bindgen/ir/Define.cpp
@@ -2,4 +2,4 @@
 
 Define::Define(std::string name) : name(std::move(name)) {}
 
-std::string Define::getName() { return name; }
+std::string Define::getName() const { return name; }

--- a/bindgen/ir/Define.h
+++ b/bindgen/ir/Define.h
@@ -7,7 +7,7 @@ class Define {
   public:
     explicit Define(std::string name);
 
-    std::string getName();
+    std::string getName() const;
 
   protected:
     std::string name;

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -40,12 +40,12 @@ void IR::addLiteralDefine(std::string name, std::string literal,
 
 void IR::addPossibleVarDefine(const std::string &macroName,
                               const std::string &varName) {
-    possibleVarDefines.emplace_back(macroName, varName, "");
+    possibleVarDefines.emplace_back(macroName, varName, "", false);
 }
 
 void IR::addVarDefine(const std::string &macroName, const std::string &varName,
-                      const std::string &type) {
-    varDefines.emplace_back(macroName, varName, type);
+                      const std::string &type, bool isConst) {
+    varDefines.emplace_back(macroName, varName, type, isConst);
 }
 
 bool IR::libObjEmpty() const {

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -185,6 +185,8 @@ void IR::filterDeclarations(const std::string &excludePrefix) {
     filterByPrefix(functions, excludePrefix);
 
     filterByPrefix(literalDefines, excludePrefix);
+
+    filterByPrefix(varDefines, excludePrefix);
 }
 
 void IR::filterTypeDefs(const std::string &excludePrefix) {

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -290,9 +290,8 @@ std::string IR::getDefineForVar(const std::string &varName) const {
     return "";
 }
 
-Variable *IR::addVariable(const std::string &name, const std::string &type,
-                          bool isConst) {
-    Variable *variable = new Variable(name, type, isConst);
+Variable *IR::addVariable(const std::string &name, const std::string &type) {
+    Variable *variable = new Variable(name, type);
     variables.push_back(variable);
     return variable;
 }

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -40,12 +40,11 @@ void IR::addLiteralDefine(std::string name, std::string literal,
 
 void IR::addPossibleVarDefine(const std::string &macroName,
                               const std::string &varName) {
-    possibleVarDefines.emplace_back(macroName, varName, "", false);
+    possibleVarDefines.emplace_back(macroName, varName);
 }
 
-void IR::addVarDefine(const std::string &macroName, const std::string &varName,
-                      const std::string &type, bool isConst) {
-    varDefines.emplace_back(macroName, varName, type, isConst);
+void IR::addVarDefine(std::string name, Variable *variable) {
+    varDefines.emplace_back(name, variable);
 }
 
 bool IR::libObjEmpty() const {
@@ -284,9 +283,22 @@ void IR::filterByName(std::vector<T> &declarations, const std::string &name) {
 
 std::string IR::getDefineForVar(const std::string &varName) const {
     for (const auto &varDefine : possibleVarDefines) {
-        if (varDefine.getVarName() == varName) {
+        if (varDefine.getVariableName() == varName) {
             return varDefine.getName();
         }
     }
     return "";
+}
+
+Variable *IR::addVariable(const std::string &name, const std::string &type,
+                          bool isConst) {
+    Variable *variable = new Variable(name, type, isConst);
+    variables.push_back(variable);
+    return variable;
+}
+
+IR::~IR() {
+    for (auto variable : variables) {
+        std::free(variable);
+    }
 }

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -80,9 +80,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const IR &ir) {
         }
 
         for (const auto &varDefine : ir.varDefines) {
-            s << "  @name(\"" << varDefine.getVarName() << "\")\n"
-              << "  def " << varDefine.getName() << ": " << varDefine.getType()
-              << " = native.extern\n";
+            s << varDefine;
         }
 
         for (const auto &func : ir.functions) {

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -37,7 +37,7 @@ class IR {
                               const std::string &varName);
 
     void addVarDefine(const std::string &macroName, const std::string &varName,
-                      const std::string &type);
+                      const std::string &type, bool isConst);
 
     /**
      * @return true if there are no functions, types,

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -4,6 +4,7 @@
 #include "Enum.h"
 #include "Function.h"
 #include "LiteralDefine.h"
+#include "PossibleVarDefine.h"
 #include "Struct.h"
 #include "TypeDef.h"
 #include "VarDefine.h"
@@ -15,6 +16,8 @@ class IR {
   public:
     explicit IR(std::string libName, std::string linkName,
                 std::string objectName, std::string packageName);
+
+    ~IR();
 
     void addFunction(std::string name, std::vector<Parameter> parameters,
                      std::string, bool isVariadic);
@@ -36,8 +39,10 @@ class IR {
     void addPossibleVarDefine(const std::string &macroName,
                               const std::string &varName);
 
-    void addVarDefine(const std::string &macroName, const std::string &varName,
-                      const std::string &type, bool isConst);
+    void addVarDefine(std::string name, Variable *variable);
+
+    Variable *addVariable(const std::string &name, const std::string &type,
+                          bool isConst);
 
     /**
      * @return true if there are no functions, types,
@@ -134,8 +139,9 @@ class IR {
     std::vector<Union> unions;
     std::vector<Enum> enums;
     std::vector<LiteralDefine> literalDefines;
-    std::vector<VarDefine> possibleVarDefines;
+    std::vector<PossibleVarDefine> possibleVarDefines;
     std::vector<VarDefine> varDefines;
+    std::vector<Variable *> variables;
     bool generated = false; // generate type defs only once
     std::string packageName;
 };

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -41,8 +41,7 @@ class IR {
 
     void addVarDefine(std::string name, Variable *variable);
 
-    Variable *addVariable(const std::string &name, const std::string &type,
-                          bool isConst);
+    Variable *addVariable(const std::string &name, const std::string &type);
 
     /**
      * @return true if there are no functions, types,

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -6,6 +6,7 @@
 #include "LiteralDefine.h"
 #include "Struct.h"
 #include "TypeDef.h"
+#include "VarDefine.h"
 
 /**
  * Intermediate representation
@@ -32,6 +33,12 @@ class IR {
     void addLiteralDefine(std::string name, std::string literal,
                           std::string type);
 
+    void addPossibleVarDefine(const std::string &macroName,
+                              const std::string &varName);
+
+    void addVarDefine(const std::string &macroName, const std::string &varName,
+                      const std::string &type);
+
     /**
      * @return true if there are no functions, types,
      *         structs and unions
@@ -45,6 +52,12 @@ class IR {
     void generate(const std::string &excludePrefix);
 
     void removeDefine(const std::string &name);
+
+    /**
+     * @return macro name if there is a macro for the variable.
+     *         otherwise return empty string
+     */
+    std::string getDefineForVar(const std::string &varName) const;
 
   private:
     /**
@@ -106,7 +119,11 @@ class IR {
     bool existsFunctionWithName(std::string functionName);
 
     template <typename T>
-    void filter(std::vector<T> &declarations, const std::string &excludePrefix);
+    void filterByPrefix(std::vector<T> &declarations,
+                        const std::string &excludePrefix);
+
+    template <typename T>
+    void filterByName(std::vector<T> &declarations, const std::string &name);
 
     std::string libName;    // name of the library
     std::string linkName;   // name of the library to link with
@@ -117,6 +134,8 @@ class IR {
     std::vector<Union> unions;
     std::vector<Enum> enums;
     std::vector<LiteralDefine> literalDefines;
+    std::vector<VarDefine> possibleVarDefines;
+    std::vector<VarDefine> varDefines;
     bool generated = false; // generate type defs only once
     std::string packageName;
 };

--- a/bindgen/ir/PossibleVarDefine.cpp
+++ b/bindgen/ir/PossibleVarDefine.cpp
@@ -1,0 +1,7 @@
+#include "PossibleVarDefine.h"
+
+PossibleVarDefine::PossibleVarDefine(const std::string &name,
+                                     const std::string &variableName)
+    : Define(name), variableName(variableName) {}
+
+std::string PossibleVarDefine::getVariableName() const { return variableName; }

--- a/bindgen/ir/PossibleVarDefine.h
+++ b/bindgen/ir/PossibleVarDefine.h
@@ -1,0 +1,19 @@
+#ifndef SCALA_NATIVE_BINDGEN_POSSIBLEVARDEFINE_H
+#define SCALA_NATIVE_BINDGEN_POSSIBLEVARDEFINE_H
+
+#include "Define.h"
+
+/**
+ * Stores name of possible variable.
+ */
+class PossibleVarDefine : public Define {
+  public:
+    PossibleVarDefine(const std::string &name, const std::string &variableName);
+
+    std::string getVariableName() const;
+
+  private:
+    std::string variableName;
+};
+
+#endif // SCALA_NATIVE_BINDGEN_POSSIBLEVARDEFINE_H

--- a/bindgen/ir/VarDefine.cpp
+++ b/bindgen/ir/VarDefine.cpp
@@ -1,23 +1,17 @@
 #include "VarDefine.h"
 
-VarDefine::VarDefine(std::string name, std::string varName, std::string type,
-                     bool isConst)
-    : Define(std::move(name)), varName(std::move(varName)),
-      type(std::move(type)), isConst(isConst) {}
-
-std::string VarDefine::getVarName() const { return varName; }
-
-std::string VarDefine::getType() const { return type; }
+VarDefine::VarDefine(std::string name, Variable *variable)
+    : Define(std::move(name)), variable(variable) {}
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                               const VarDefine &varDefine) {
-    s << "  @name(\"" << varDefine.getVarName() << "\")\n";
-    if (varDefine.isConst) {
+    s << "  @name(\"" << varDefine.variable->getName() << "\")\n";
+    if (varDefine.variable->getIsConst()) {
         s << "  val ";
     } else {
         s << "  def ";
     }
-    s << varDefine.getName() << ": " << varDefine.getType()
+    s << varDefine.getName() << ": " << varDefine.variable->getType()
       << " = native.extern\n";
     return s;
 }

--- a/bindgen/ir/VarDefine.cpp
+++ b/bindgen/ir/VarDefine.cpp
@@ -1,0 +1,9 @@
+#include "VarDefine.h"
+
+VarDefine::VarDefine(std::string name, std::string varName, std::string type)
+    : Define(std::move(name)), varName(std::move(varName)),
+      type(std::move(type)) {}
+
+std::string VarDefine::getVarName() const { return varName; }
+
+std::string VarDefine::getType() const { return type; }

--- a/bindgen/ir/VarDefine.cpp
+++ b/bindgen/ir/VarDefine.cpp
@@ -7,3 +7,11 @@ VarDefine::VarDefine(std::string name, std::string varName, std::string type)
 std::string VarDefine::getVarName() const { return varName; }
 
 std::string VarDefine::getType() const { return type; }
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
+                              const VarDefine &varDefine) {
+    s << "  @name(\"" << varDefine.getVarName() << "\")\n"
+      << "  val " << varDefine.getName() << ": " << varDefine.getType()
+      << " = native.extern\n";
+    return s;
+}

--- a/bindgen/ir/VarDefine.cpp
+++ b/bindgen/ir/VarDefine.cpp
@@ -1,8 +1,9 @@
 #include "VarDefine.h"
 
-VarDefine::VarDefine(std::string name, std::string varName, std::string type)
+VarDefine::VarDefine(std::string name, std::string varName, std::string type,
+                     bool isConst)
     : Define(std::move(name)), varName(std::move(varName)),
-      type(std::move(type)) {}
+      type(std::move(type)), isConst(isConst) {}
 
 std::string VarDefine::getVarName() const { return varName; }
 
@@ -10,8 +11,13 @@ std::string VarDefine::getType() const { return type; }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                               const VarDefine &varDefine) {
-    s << "  @name(\"" << varDefine.getVarName() << "\")\n"
-      << "  val " << varDefine.getName() << ": " << varDefine.getType()
+    s << "  @name(\"" << varDefine.getVarName() << "\")\n";
+    if (varDefine.isConst) {
+        s << "  val ";
+    } else {
+        s << "  def ";
+    }
+    s << varDefine.getName() << ": " << varDefine.getType()
       << " = native.extern\n";
     return s;
 }

--- a/bindgen/ir/VarDefine.cpp
+++ b/bindgen/ir/VarDefine.cpp
@@ -5,13 +5,8 @@ VarDefine::VarDefine(std::string name, Variable *variable)
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                               const VarDefine &varDefine) {
-    s << "  @name(\"" << varDefine.variable->getName() << "\")\n";
-    if (varDefine.variable->getIsConst()) {
-        s << "  val ";
-    } else {
-        s << "  def ";
-    }
-    s << varDefine.getName() << ": " << varDefine.variable->getType()
-      << " = native.extern\n";
+    s << "  @name(\"" << varDefine.variable->getName() << "\")\n"
+      << "  val " << varDefine.getName() << ": "
+      << varDefine.variable->getType() << " = native.extern\n";
     return s;
 }

--- a/bindgen/ir/VarDefine.h
+++ b/bindgen/ir/VarDefine.h
@@ -2,24 +2,21 @@
 #define SCALA_NATIVE_BINDGEN_VARDEFINE_H
 
 #include "Define.h"
+#include "Variable.h"
 #include <llvm/Support/raw_ostream.h>
 
+/**
+ * Stores a pointer to Variable instance from IR
+ */
 class VarDefine : public Define {
   public:
-    VarDefine(std::string name, std::string varName, std::string type,
-              bool isConst);
-
-    std::string getVarName() const;
-
-    std::string getType() const;
+    VarDefine(std::string name, Variable *variable);
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const VarDefine &varDefine);
 
   private:
-    std::string varName;
-    std::string type;
-    bool isConst;
+    Variable *variable;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_VARDEFINE_H

--- a/bindgen/ir/VarDefine.h
+++ b/bindgen/ir/VarDefine.h
@@ -2,6 +2,7 @@
 #define SCALA_NATIVE_BINDGEN_VARDEFINE_H
 
 #include "Define.h"
+#include <llvm/Support/raw_ostream.h>
 
 class VarDefine : public Define {
   public:
@@ -10,6 +11,9 @@ class VarDefine : public Define {
     std::string getVarName() const;
 
     std::string getType() const;
+
+    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
+                                         const VarDefine &varDefine);
 
   private:
     std::string varName;

--- a/bindgen/ir/VarDefine.h
+++ b/bindgen/ir/VarDefine.h
@@ -6,7 +6,8 @@
 
 class VarDefine : public Define {
   public:
-    VarDefine(std::string name, std::string varName, std::string type);
+    VarDefine(std::string name, std::string varName, std::string type,
+              bool isConst);
 
     std::string getVarName() const;
 
@@ -18,6 +19,7 @@ class VarDefine : public Define {
   private:
     std::string varName;
     std::string type;
+    bool isConst;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_VARDEFINE_H

--- a/bindgen/ir/VarDefine.h
+++ b/bindgen/ir/VarDefine.h
@@ -1,0 +1,19 @@
+#ifndef SCALA_NATIVE_BINDGEN_VARDEFINE_H
+#define SCALA_NATIVE_BINDGEN_VARDEFINE_H
+
+#include "Define.h"
+
+class VarDefine : public Define {
+  public:
+    VarDefine(std::string name, std::string varName, std::string type);
+
+    std::string getVarName() const;
+
+    std::string getType() const;
+
+  private:
+    std::string varName;
+    std::string type;
+};
+
+#endif // SCALA_NATIVE_BINDGEN_VARDEFINE_H

--- a/bindgen/ir/Variable.cpp
+++ b/bindgen/ir/Variable.cpp
@@ -1,0 +1,7 @@
+#include "Variable.h"
+
+Variable::Variable(const std::string &name, const std::string &type,
+                   bool isConst)
+    : TypeAndName(name, type), isConst(isConst) {}
+
+bool Variable::getIsConst() { return isConst; }

--- a/bindgen/ir/Variable.cpp
+++ b/bindgen/ir/Variable.cpp
@@ -1,7 +1,4 @@
 #include "Variable.h"
 
-Variable::Variable(const std::string &name, const std::string &type,
-                   bool isConst)
-    : TypeAndName(name, type), isConst(isConst) {}
-
-bool Variable::getIsConst() { return isConst; }
+Variable::Variable(const std::string &name, const std::string &type)
+    : TypeAndName(name, type) {}

--- a/bindgen/ir/Variable.h
+++ b/bindgen/ir/Variable.h
@@ -5,12 +5,7 @@
 
 class Variable : public TypeAndName {
   public:
-    Variable(const std::string &name, const std::string &type, bool isConst);
-
-    bool getIsConst();
-
-  private:
-    bool isConst;
+    Variable(const std::string &name, const std::string &type);
 };
 
 #endif // SCALA_NATIVE_BINDGEN_VARIABLE_H

--- a/bindgen/ir/Variable.h
+++ b/bindgen/ir/Variable.h
@@ -1,0 +1,16 @@
+#ifndef SCALA_NATIVE_BINDGEN_VARIABLE_H
+#define SCALA_NATIVE_BINDGEN_VARIABLE_H
+
+#include "TypeAndName.h"
+
+class Variable : public TypeAndName {
+  public:
+    Variable(const std::string &name, const std::string &type, bool isConst);
+
+    bool getIsConst();
+
+  private:
+    bool isConst;
+};
+
+#endif // SCALA_NATIVE_BINDGEN_VARIABLE_H

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -159,3 +159,18 @@ void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
     ir.addStruct(name, fields,
                  astContext->getTypeSize(record->getTypeForDecl()));
 }
+
+bool TreeVisitor::VisitVarDecl(clang::VarDecl *varDecl) {
+    if (!varDecl->isThisDeclarationADefinition()) {
+        /* check if there is a macro for the variable.
+         * Macros were saved by DefineFinder */
+        std::string varName = varDecl->getName().str();
+        std::string macroName = ir.getDefineForVar(varName);
+        if (!macroName.empty()) {
+            std::string type = handleReservedWords(
+                typeTranslator.Translate(varDecl->getType()));
+            ir.addVarDefine(macroName, varName, type);
+        }
+    }
+    return true;
+}

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -162,15 +162,16 @@ void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
 
 bool TreeVisitor::VisitVarDecl(clang::VarDecl *varDecl) {
     if (!varDecl->isThisDeclarationADefinition()) {
+        std::string variableName = varDecl->getName().str();
+        std::string type =
+            handleReservedWords(typeTranslator.Translate(varDecl->getType()));
+        Variable *variable = ir.addVariable(
+            variableName, type, varDecl->getType().isConstQualified());
         /* check if there is a macro for the variable.
          * Macros were saved by DefineFinder */
-        std::string varName = varDecl->getName().str();
-        std::string macroName = ir.getDefineForVar(varName);
+        std::string macroName = ir.getDefineForVar(variableName);
         if (!macroName.empty()) {
-            std::string type = handleReservedWords(
-                typeTranslator.Translate(varDecl->getType()));
-            ir.addVarDefine(macroName, varName, type,
-                            varDecl->getType().isConstQualified());
+            ir.addVarDefine(macroName, variable);
         }
     }
     return true;

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -165,8 +165,7 @@ bool TreeVisitor::VisitVarDecl(clang::VarDecl *varDecl) {
         std::string variableName = varDecl->getName().str();
         std::string type =
             handleReservedWords(typeTranslator.Translate(varDecl->getType()));
-        Variable *variable = ir.addVariable(
-            variableName, type, varDecl->getType().isConstQualified());
+        Variable *variable = ir.addVariable(variableName, type);
         /* check if there is a macro for the variable.
          * Macros were saved by DefineFinder */
         std::string macroName = ir.getDefineForVar(variableName);

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -169,7 +169,8 @@ bool TreeVisitor::VisitVarDecl(clang::VarDecl *varDecl) {
         if (!macroName.empty()) {
             std::string type = handleReservedWords(
                 typeTranslator.Translate(varDecl->getType()));
-            ir.addVarDefine(macroName, varName, type);
+            ir.addVarDefine(macroName, varName, type,
+                            varDecl->getType().isConstQualified());
         }
     }
     return true;

--- a/bindgen/visitor/TreeVisitor.h
+++ b/bindgen/visitor/TreeVisitor.h
@@ -37,4 +37,5 @@ class TreeVisitor : public clang::RecursiveASTVisitor<TreeVisitor> {
     virtual bool VisitTypedefDecl(clang::TypedefDecl *tpdef);
     virtual bool VisitEnumDecl(clang::EnumDecl *enumdecl);
     virtual bool VisitRecordDecl(clang::RecordDecl *record);
+    virtual bool VisitVarDecl(clang::VarDecl *VD);
 };

--- a/tests/samples/LiteralDefine.h
+++ b/tests/samples/LiteralDefine.h
@@ -19,9 +19,6 @@
 #define NEW_INT INT
 #define NEG_INT -INT
 
-extern int a;
-#define MY_A a // unsupported
-
 #define __PRIVATE 1
 
 #define wait_for_it(cond)                                                      \

--- a/tests/samples/VarDefine.c
+++ b/tests/samples/VarDefine.c
@@ -1,3 +1,5 @@
 #include "VarDefine.h"
 
 int a = 23;
+const int constInt = 10;
+const int *constIntPointer = 0;

--- a/tests/samples/VarDefine.c
+++ b/tests/samples/VarDefine.c
@@ -1,5 +1,3 @@
 #include "VarDefine.h"
 
 int a = 23;
-
-int getA() { return a; }

--- a/tests/samples/VarDefine.c
+++ b/tests/samples/VarDefine.c
@@ -1,0 +1,5 @@
+#include "VarDefine.h"
+
+int a = 23;
+
+int getA() { return a; }

--- a/tests/samples/VarDefine.h
+++ b/tests/samples/VarDefine.h
@@ -7,4 +7,7 @@ extern int c;
 #define C c
 #undef C // removed
 
+extern float f;
+#define __PRIVATE f // should be filtered
+
 int getA();

--- a/tests/samples/VarDefine.h
+++ b/tests/samples/VarDefine.h
@@ -1,0 +1,10 @@
+extern int a;
+#define A a
+
+#define B b // ignored because there is no such variable
+
+extern int c;
+#define C c
+#undef C // removed
+
+int getA();

--- a/tests/samples/VarDefine.h
+++ b/tests/samples/VarDefine.h
@@ -9,5 +9,3 @@ extern int c;
 
 extern float f;
 #define __PRIVATE f // should be filtered
-
-int getA();

--- a/tests/samples/VarDefine.h
+++ b/tests/samples/VarDefine.h
@@ -1,6 +1,12 @@
 extern int a;
 #define A a
 
+extern const int constInt;
+#define CONST_INT constInt
+
+extern const int *constIntPointer;
+#define CONST_INT_POINTER constIntPointer
+
 #define B b // ignored because there is no such variable
 
 extern int c;

--- a/tests/samples/VarDefine.scala
+++ b/tests/samples/VarDefine.scala
@@ -7,9 +7,9 @@ import scala.scalanative.native._
 @native.extern
 object VarDefine {
   @name("a")
-  def A: native.CInt = native.extern
+  val A: native.CInt = native.extern
   @name("constInt")
   val CONST_INT: native.CInt = native.extern
   @name("constIntPointer")
-  def CONST_INT_POINTER: native.Ptr[native.CInt] = native.extern
+  val CONST_INT_POINTER: native.Ptr[native.CInt] = native.extern
 }

--- a/tests/samples/VarDefine.scala
+++ b/tests/samples/VarDefine.scala
@@ -1,0 +1,12 @@
+package org.scalanative.bindgen.samples
+
+import scala.scalanative._
+import scala.scalanative.native._
+
+@native.link("bindgentests")
+@native.extern
+object VarDefine {
+  @name("a")
+  def A: native.CInt = native.extern
+  def getA(): native.CInt = native.extern
+}

--- a/tests/samples/VarDefine.scala
+++ b/tests/samples/VarDefine.scala
@@ -7,5 +7,9 @@ import scala.scalanative.native._
 @native.extern
 object VarDefine {
   @name("a")
-  val A: native.CInt = native.extern
+  def A: native.CInt = native.extern
+  @name("constInt")
+  val CONST_INT: native.CInt = native.extern
+  @name("constIntPointer")
+  def CONST_INT_POINTER: native.Ptr[native.CInt] = native.extern
 }

--- a/tests/samples/VarDefine.scala
+++ b/tests/samples/VarDefine.scala
@@ -7,6 +7,5 @@ import scala.scalanative.native._
 @native.extern
 object VarDefine {
   @name("a")
-  def A: native.CInt = native.extern
-  def getA(): native.CInt = native.extern
+  val A: native.CInt = native.extern
 }

--- a/tests/samples/src/test/scala/org/scalanative/bindgen/samples/VarDefineTests.scala
+++ b/tests/samples/src/test/scala/org/scalanative/bindgen/samples/VarDefineTests.scala
@@ -1,0 +1,11 @@
+package org.scalanative.bindgen.samples
+
+import utest._
+
+object VarDefineTests extends TestSuite {
+  val tests = Tests {
+    'getA - {
+      assert(VarDefine.getA() == 23)
+    }
+  }
+}

--- a/tests/samples/src/test/scala/org/scalanative/bindgen/samples/VarDefineTests.scala
+++ b/tests/samples/src/test/scala/org/scalanative/bindgen/samples/VarDefineTests.scala
@@ -5,7 +5,7 @@ import utest._
 object VarDefineTests extends TestSuite {
   val tests = Tests {
     'getA - {
-      assert(VarDefine.getA() == 23)
+      assert(VarDefine.A == 23)
     }
   }
 }

--- a/tests/samples/src/test/scala/org/scalanative/bindgen/samples/VarDefineTests.scala
+++ b/tests/samples/src/test/scala/org/scalanative/bindgen/samples/VarDefineTests.scala
@@ -6,6 +6,7 @@ object VarDefineTests extends TestSuite {
   val tests = Tests {
     'getA - {
       assert(VarDefine.A == 23)
+      assert(VarDefine.CONST_INT == 10)
     }
   }
 }


### PR DESCRIPTION
During `DefineFinderAction` save all defines that use an identifier.
During AST traversal find variables declarations and check if there is a define for the variable.
If such define exist then save it in a vector field in IR and generate Scala code for it:
```c
extern int a;
#define A a
```

```scala
  @name("a")
  def A: native.CInt = native.extern
```