### PR TITLE
Fix #33: Configure CMake to build statically linked binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
       script: scripts/docker-deploy.sh latest
       on:
         branch: master
-  - env: TEST_ENV=ubuntu-18.04-llvm-dev
   - env: TEST_ENV=ubuntu-18.04-llvm-5.0
 
 before_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,13 @@ RUN set -x \
  && apt update \
  && apt install -y --no-install-recommends \
             g++ openjdk-8-jdk-headless sbt cmake make curl git \
+            zlib1g-dev \
             libgc-dev libunwind8-dev libre2-dev \
  && rm -rf /var/lib/apt/lists/*
 
 ARG LLVM_VERSION=6.0
 ENV LLVM_VERSION=$LLVM_VERSION
-# LLVM dev versions do not have a "-x.y" version suffix.
-ARG LLVM_DEB_COMPONENT=-$LLVM_VERSION
 RUN set -x \
- && . /etc/lsb-release \
- && echo "deb https://apt.llvm.org/$DISTRIB_CODENAME/ llvm-toolchain-$DISTRIB_CODENAME$LLVM_DEB_COMPONENT main" > /etc/apt/sources.list.d/llvm.list \
- && apt-key adv --fetch-keys https://apt.llvm.org/llvm-snapshot.gpg.key \
  && apt update \
  && apt install -y --no-install-recommends \
             clang-$LLVM_VERSION clang-format-$LLVM_VERSION \

--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -1,51 +1,19 @@
 cmake_minimum_required(VERSION 3.9)
 project(scala-native-bindgen)
 
+set(USE_SHARED OFF)
+
 # Locate LLVMConfig.cmake
-#find_package(LLVM REQUIRED CONFIG)
-#message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-#message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+find_package(LLVM REQUIRED CONFIG)
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-find_program(LLVM_CONFIG_PROGRAM
-  NAMES
-#  llvm-config-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}
-  llvm-config-6.0
-  llvm-config-5.0
-  llvm-config-4.0
-  llvm-config
-)
+message(STATUS "Using LLVM include dirs: ${LLVM_INCLUDE_DIRS}")
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 
-execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --includedir
-  OUTPUT_VARIABLE LLVM_INCLUDE_DIR
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-message(STATUS "Using LLVM include dir: ${LLVM_INCLUDE_DIR}")
+message(STATUS "Using LLVM defs: ${LLVM_DEFINITIONS}")
+add_definitions(${LLVM_DEFINITIONS})
 
-execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --cxxflags
-  OUTPUT_VARIABLE LLVM_CXX_FLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-message(STATUS "Using LLVM CXXFLAGS: ${LLVM_CXX_FLAGS}")
-
-execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --ldflags
-  OUTPUT_VARIABLE LLVM_LINKER_FLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-message(STATUS "Using LLVM LDFLAGS: ${LLVM_LINKER_FLAGS}")
-
-execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --libs --link-static
-  OUTPUT_VARIABLE LLVM_LIBS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --system-libs --link-static
-  OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LLVM_CXX_FLAGS}")
 add_compile_options(-fexceptions -std=c++11 -Wall -Wconversion -Werror)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -53,10 +21,14 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # discourages statically linked binaries. Instead add -L/usr/lib before the
   # LLVM LDFLAGS to link against the dynamic system libc++ instead of the one
   # from LLVM.
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/lib ${LLVM_LINKER_FLAGS}")
+  set(BINDGEN_LINK_FLAG "-L/usr/lib")
 else()
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LLVM_LINKER_FLAGS} -static")
+  set(BINDGEN_LINK_FLAG "-static")
 endif()
+message(STATUS "Using link flag: ${BINDGEN_LINK_FLAG}")
+
+message(STATUS "Using LLVM library directories: ${LLVM_LIBRARY_DIRS}")
+link_directories(${LLVM_LIBRARY_DIRS})
 
 add_executable(bindgen
   Main.cpp
@@ -116,27 +88,23 @@ add_executable(bindgen
 set_target_properties(bindgen
   PROPERTIES
   OUTPUT_NAME scala-native-bindgen
+  LINK_FLAGS "${BINDGEN_LINK_FLAG}"
 )
+
+llvm_map_components_to_libnames(LLVM_LIBS support core irreader object option profiledata)
 
 target_link_libraries(bindgen
   PRIVATE
   clangFrontend
   clangTooling
-
-  clangFrontend
   clangSerialization
   clangDriver
-  clangTooling
   clangParse
   clangSema
-
   clangAnalysis
-
   clangEdit
   clangAST
   clangLex
   clangBasic
-
-  "${LLVM_LIBS}"
-  "${LLVM_SYSTEM_LIBS}"
+  ${LLVM_LIBS}
 )

--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -1,15 +1,54 @@
 cmake_minimum_required(VERSION 3.9)
 project(scala-native-bindgen)
 
-# Locate $LLVM_PATH/lib/cmake/clang/ClangConfig.cmake
-find_package(Clang REQUIRED CONFIG)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+# Locate LLVMConfig.cmake
+#find_package(LLVM REQUIRED CONFIG)
+#message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+#message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
-add_definitions(${LLVM_DEFINITIONS})
+find_program(LLVM_CONFIG_PROGRAM
+  NAMES
+#  llvm-config-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}
+  llvm-config-6.0
+  llvm-config-5.0
+  llvm-config-4.0
+  llvm-config
+)
 
-add_compile_options(-fexceptions -std=c++11 -Wall -Wconversion -Werror)
+execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --includedir
+  OUTPUT_VARIABLE LLVM_INCLUDE_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS "Using LLVM include dir: ${LLVM_INCLUDE_DIR}")
+
+execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --cxxflags
+  OUTPUT_VARIABLE LLVM_CXX_FLAGS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS "Using LLVM CXXFLAGS: ${LLVM_CXX_FLAGS}")
+
+execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --ldflags
+  OUTPUT_VARIABLE LLVM_LINKER_FLAGS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS "Using LLVM LDFLAGS: ${LLVM_LINKER_FLAGS}")
+
+execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --libs --link-static
+  OUTPUT_VARIABLE LLVM_LIBS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --system-libs --link-static
+  OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LLVM_CXX_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LLVM_LINKER_FLAGS} -static")
+
+add_compile_options(-fexceptions -std=c++11 -Wall -Wconversion) # -Werror)
 
 add_executable(bindgen
   Main.cpp
@@ -75,4 +114,21 @@ target_link_libraries(bindgen
   PRIVATE
   clangFrontend
   clangTooling
+
+  clangFrontend
+  clangSerialization
+  clangDriver
+  clangTooling
+  clangParse
+  clangSema
+
+  clangAnalysis
+
+  clangEdit
+  clangAST
+  clangLex
+  clangBasic
+
+  "${LLVM_LIBS}"
+  "${LLVM_SYSTEM_LIBS}"
 )

--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -46,6 +46,7 @@ execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --system-libs --link-static
 include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LLVM_CXX_FLAGS}")
+add_compile_options(-fexceptions -std=c++11 -Wall -Wconversion -Werror)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # macOS does not guarantee backwards compatible system calls and therefore
@@ -56,8 +57,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 else()
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LLVM_LINKER_FLAGS} -static")
 endif()
-
-add_compile_options(-Wall -Wconversion)
 
 add_executable(bindgen
   Main.cpp

--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -46,9 +46,18 @@ execute_process(COMMAND ${LLVM_CONFIG_PROGRAM} --system-libs --link-static
 include_directories(SYSTEM ${LLVM_INCLUDE_DIR})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LLVM_CXX_FLAGS}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LLVM_LINKER_FLAGS} -static")
 
-add_compile_options(-fexceptions -std=c++11 -Wall -Wconversion) # -Werror)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # macOS does not guarantee backwards compatible system calls and therefore
+  # discourages statically linked binaries. Instead add -L/usr/lib before the
+  # LLVM LDFLAGS to link against the dynamic system libc++ instead of the one
+  # from LLVM.
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/lib ${LLVM_LINKER_FLAGS}")
+else()
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LLVM_LINKER_FLAGS} -static")
+endif()
+
+add_compile_options(-Wall -Wconversion)
 
 add_executable(bindgen
   Main.cpp

--- a/bindgen/Dockerfile
+++ b/bindgen/Dockerfile
@@ -11,16 +11,8 @@ RUN set -x \
  && cmake .. \
  && make
 
-ARG UBUNTU_VERSION=18.04
-FROM ubuntu:$UBUNTU_VERSION
+FROM scratch
 
-ARG LLVM_VERSION=6.0
-ENV LLVM_VERSION=$LLVM_VERSION
-RUN set -x \
- && apt update \
- && apt install -y --no-install-recommends libclang1-$LLVM_VERSION \
- && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /src/target/scala-native-bindgen /usr/bin/scala-native-bindgen
+COPY --from=builder /src/target/scala-native-bindgen /scala-native-bindgen
 WORKDIR /src
-ENTRYPOINT ["scala-native-bindgen"]
+ENTRYPOINT ["/scala-native-bindgen"]

--- a/bindgen/Main.cpp
+++ b/bindgen/Main.cpp
@@ -2,7 +2,7 @@
 #include "visitor/ScalaFrontendActionFactory.h"
 #include <clang/Tooling/CommonOptionsParser.h>
 
-int main(int argc, char *argv[]) {
+int main(int argc, const char *argv[]) {
     llvm::cl::OptionCategory Category("Binding Generator");
     llvm::cl::extrahelp CommonHelp(
         clang::tooling::CommonOptionsParser::HelpMessage);
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
     llvm::cl::opt<std::string> LinkName(
         "link", llvm::cl::cat(Category),
         llvm::cl::desc("Library to link with, e.g. -luv for libuv"));
-    clang::tooling::CommonOptionsParser op(argc, (const char **)argv, Category);
+    clang::tooling::CommonOptionsParser op(argc, argv, Category);
     clang::tooling::ClangTool Tool(op.getCompilations(),
                                    op.getSourcePathList());
 

--- a/bindgen/visitor/TreeVisitor.h
+++ b/bindgen/visitor/TreeVisitor.h
@@ -26,6 +26,7 @@ class TreeVisitor : public clang::RecursiveASTVisitor<TreeVisitor> {
     TreeVisitor(clang::CompilerInstance *CI, IR &ir)
         : astContext(&(CI->getASTContext())), typeTranslator(astContext, ir),
           cycleDetection(typeTranslator), ir(ir) {}
+    virtual ~TreeVisitor() {}
 
     virtual bool VisitFunctionDecl(clang::FunctionDecl *func);
     virtual bool VisitTypedefDecl(clang::TypedefDecl *tpdef);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,20 +10,6 @@ services:
         - LLVM_VERSION=6.0
     entrypoint: [scala-native-bindgen]
 
-  ubuntu-18.04-llvm-dev:
-    image: scalabindgen/scala-native-bindgen-builder:ubuntu-18.04-llvm-dev
-    build:
-      context: .
-      args:
-        - UBUNTU_VERSION=18.04
-        - LLVM_VERSION=7
-        - LLVM_DEB_COMPONENT=
-    command: scripts/test.sh
-    volumes:
-      - .:/src
-      - ${HOME}/.ivy2:/root/.ivy2
-      - ${HOME}/.sbt:/root/.sbt
-
   ubuntu-18.04-llvm-6.0:
     image: scalabindgen/scala-native-bindgen-builder:ubuntu-18.04-llvm-6.0
     build:


### PR DESCRIPTION
Tested on macOS with the caveat that static linked executables are not supported however all LLVM dependencies are statically linked.