### PR TITLE
Pin the bindgen docker image version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
      docker-compose run --rm $TEST_ENV scripts/clangfmt --test;
    fi
  - if [[ "$TEST_ENV" = *llvm-6.0 ]]; then
+     export VERSION="${TRAVIS_COMMIT}";
      docker-compose build bindgen;
      find . -name target | xargs sudo rm -rf;
      scripts/docker-test.sh;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   bindgen:
-    image: scalabindgen/scala-native-bindgen
+    image: scalabindgen/scala-native-bindgen:${VERSION:-latest}
     build:
       context: bindgen
       args:

--- a/scripts/docker-bindgen.sh
+++ b/scripts/docker-bindgen.sh
@@ -14,4 +14,4 @@ if [[ "$#" -gt 1 ]] && [[ "$1" == /* ]]; then
   volumes+="--volume=$1:$1"  
 fi
 
-exec docker run --rm "${volumes[@]}" scalabindgen/scala-native-bindgen "$@"
+exec docker run --rm "${volumes[@]}" "scalabindgen/scala-native-bindgen:${VERSION:-latest}" "$@"

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -14,6 +14,8 @@ outdir="tests/target/docker-samples"
 rm -rf "$outdir"
 mkdir -p "$outdir"
 
+echo "Using version '${VERSION:-latest}'"
+
 for input in tests/samples/*.h; do
   name="$(basename "$input" .h)"
   output="$outdir/$name.scala"


### PR DESCRIPTION
Use the commit ID as the docker version to avoid accidental fallback
to 'latest' from docker hub.