### PR TITLE
Fix segfault and memory management

### DIFF
--- a/bindgen/CycleDetection.h
+++ b/bindgen/CycleDetection.h
@@ -35,6 +35,10 @@ class CycleDetection {
         }
 
         Type *type = tpeTransl.translate(qtpe);
+        if (type == nullptr) {
+            return;
+        }
+
         std::string qtpeString = type->str();
         if (type->canBeDeallocated()) {
             delete type;

--- a/bindgen/CycleDetection.h
+++ b/bindgen/CycleDetection.h
@@ -34,15 +34,12 @@ class CycleDetection {
             return;
         }
 
-        Type *type = tpeTransl.translate(qtpe);
+        std::shared_ptr<Type> type = tpeTransl.translate(qtpe);
         if (type == nullptr) {
             return;
         }
 
         std::string qtpeString = type->str();
-        if (type->canBeDeallocated()) {
-            delete type;
-        }
 
         // Add the dependence of qtpe
         if (contains(qtpeString)) {

--- a/bindgen/TypeTranslator.cpp
+++ b/bindgen/TypeTranslator.cpp
@@ -106,7 +106,15 @@ Type *TypeTranslator::translateStructOrUnion(const clang::QualType &qtpe) {
 Type *TypeTranslator::translateConstantArray(const clang::ConstantArrayType *ar,
                                              const std::string *avoid) {
     const uint64_t size = ar->getSize().getZExtValue();
-    return new ArrayType(translate(ar->getElementType(), avoid), size);
+    Type *elementType = translate(ar->getElementType(), avoid);
+    if (elementType == nullptr) {
+        llvm::errs() << "Failed to translate array type "
+                     << ar->getElementType().getAsString()
+                     << "\n";
+        elementType = new PrimitiveType("Byte");
+    }
+
+    return new ArrayType(elementType, size);
 }
 
 Type *TypeTranslator::translate(const clang::QualType &qtpe,

--- a/bindgen/TypeTranslator.cpp
+++ b/bindgen/TypeTranslator.cpp
@@ -32,22 +32,24 @@ TypeTranslator::TypeTranslator(clang::ASTContext *ctx_, IR &ir)
     typeMap["double"] = "native.CDouble";
 }
 
-Type *TypeTranslator::translateFunctionPointer(const clang::QualType &qtpe,
-                                               const std::string *avoid) {
+std::shared_ptr<Type>
+TypeTranslator::translateFunctionPointer(const clang::QualType &qtpe,
+                                         const std::string *avoid) {
     const auto *ptr = qtpe.getTypePtr()->getAs<clang::PointerType>();
     const clang::QualType &inner = ptr->getPointeeType();
 
     if (inner->isFunctionProtoType()) {
         const auto *fc = inner->getAs<clang::FunctionProtoType>();
-        Type *returnType = translate(fc->getReturnType(), avoid);
-        std::vector<Type *> parametersTypes;
+        std::shared_ptr<Type> returnType =
+            translate(fc->getReturnType(), avoid);
+        std::vector<std::shared_ptr<Type>> parametersTypes;
 
         for (const clang::QualType &param : fc->param_types()) {
             parametersTypes.push_back(translate(param, avoid));
         }
 
-        return new FunctionPointerType(returnType, parametersTypes,
-                                       fc->isVariadic());
+        return std::make_shared<FunctionPointerType>(
+            returnType, parametersTypes, fc->isVariadic());
 
     } else {
         llvm::errs() << "Unsupported function pointer type: "
@@ -57,29 +59,31 @@ Type *TypeTranslator::translateFunctionPointer(const clang::QualType &qtpe,
     }
 }
 
-Type *TypeTranslator::translatePointer(const clang::QualType &pte,
-                                       const std::string *avoid) {
+std::shared_ptr<Type>
+TypeTranslator::translatePointer(const clang::QualType &pte,
+                                 const std::string *avoid) {
 
     if (pte->isBuiltinType()) {
         const clang::BuiltinType *as = pte->getAs<clang::BuiltinType>();
 
         // Take care of void*
         if (as->getKind() == clang::BuiltinType::Void) {
-            return new PointerType(new PrimitiveType("Byte"));
+            return std::make_shared<PointerType>(
+                std::make_shared<PrimitiveType>("Byte"));
         }
 
         // Take care of char*
         if (as->getKind() == clang::BuiltinType::Char_S ||
             as->getKind() == clang::BuiltinType::SChar) {
             // TODO: new PointerType(new PrimitiveType("native.CChar"))
-            return new PrimitiveType("native.CString");
+            return std::make_shared<PrimitiveType>("native.CString");
         }
     }
 
-    return new PointerType(translate(pte, avoid));
+    return std::make_shared<PointerType>(translate(pte, avoid));
 }
 
-Type *
+std::shared_ptr<Type>
 TypeTranslator::translateStructOrUnionOrEnum(const clang::QualType &qtpe) {
     std::string name = qtpe.getUnqualifiedType().getAsString();
 
@@ -93,32 +97,34 @@ TypeTranslator::translateStructOrUnionOrEnum(const clang::QualType &qtpe) {
     return ir.getTypeDefWithName(name);
 }
 
-Type *TypeTranslator::translateStructOrUnion(const clang::QualType &qtpe) {
+std::shared_ptr<Type>
+TypeTranslator::translateStructOrUnion(const clang::QualType &qtpe) {
     if (qtpe->hasUnnamedOrLocalType()) {
         // TODO: Verify that the local part is not a problem
         uint64_t size = ctx->getTypeSize(qtpe);
-        return new ArrayType(new PrimitiveType("Byte"), size);
+        return std::make_shared<ArrayType>(
+            std::make_shared<PrimitiveType>("Byte"), size);
     }
 
     return translateStructOrUnionOrEnum(qtpe);
 }
 
-Type *TypeTranslator::translateConstantArray(const clang::ConstantArrayType *ar,
-                                             const std::string *avoid) {
+std::shared_ptr<Type>
+TypeTranslator::translateConstantArray(const clang::ConstantArrayType *ar,
+                                       const std::string *avoid) {
     const uint64_t size = ar->getSize().getZExtValue();
-    Type *elementType = translate(ar->getElementType(), avoid);
+    std::shared_ptr<Type> elementType = translate(ar->getElementType(), avoid);
     if (elementType == nullptr) {
         llvm::errs() << "Failed to translate array type "
-                     << ar->getElementType().getAsString()
-                     << "\n";
-        elementType = new PrimitiveType("Byte");
+                     << ar->getElementType().getAsString() << "\n";
+        elementType = std::make_shared<PrimitiveType>("Byte");
     }
 
-    return new ArrayType(elementType, size);
+    return std::make_shared<ArrayType>(elementType, size);
 }
 
-Type *TypeTranslator::translate(const clang::QualType &qtpe,
-                                const std::string *avoid) {
+std::shared_ptr<Type> TypeTranslator::translate(const clang::QualType &qtpe,
+                                                const std::string *avoid) {
 
     const clang::Type *tpe = qtpe.getTypePtr();
 
@@ -126,7 +132,8 @@ Type *TypeTranslator::translate(const clang::QualType &qtpe,
         // This is a type that we want to avoid the usage.
         // Êxample: A struct that has a pointer to itself
         uint64_t size = ctx->getTypeSize(tpe);
-        return new ArrayType(new PrimitiveType("Byte"), size);
+        return std::make_shared<ArrayType>(
+            std::make_shared<PrimitiveType>("Byte"), size);
     }
 
     if (tpe->isFunctionPointerType()) {
@@ -154,7 +161,7 @@ Type *TypeTranslator::translate(const clang::QualType &qtpe,
 
         auto found = typeMap.find(qtpe.getUnqualifiedType().getAsString());
         if (found != typeMap.end()) {
-            return new PrimitiveType(found->second);
+            return std::make_shared<PrimitiveType>(found->second);
         } else {
             return ir.getTypeDefWithName(
                 qtpe.getUnqualifiedType().getAsString());
@@ -162,7 +169,7 @@ Type *TypeTranslator::translate(const clang::QualType &qtpe,
     }
 }
 
-void TypeTranslator::addAlias(std::string cName, Type *type) {
+void TypeTranslator::addAlias(std::string cName, std::shared_ptr<Type> type) {
     aliasesMap[cName] = type;
 }
 

--- a/bindgen/TypeTranslator.h
+++ b/bindgen/TypeTranslator.h
@@ -14,9 +14,10 @@ class TypeTranslator {
      * structs, unions, ...
      * @return the type translated
      */
-    Type *translate(const clang::QualType &tpe, const std::string * = nullptr);
+    std::shared_ptr<Type> translate(const clang::QualType &tpe,
+                                    const std::string * = nullptr);
 
-    void addAlias(std::string cName, Type *type);
+    void addAlias(std::string cName, std::shared_ptr<Type> type);
 
     std::string getTypeFromTypeMap(std::string cType);
 
@@ -32,18 +33,20 @@ class TypeTranslator {
     /**
      * Maps C struct, union or enum name to Type alias
      */
-    std::map<std::string, Type *> aliasesMap;
+    std::map<std::string, std::shared_ptr<Type>> aliasesMap;
 
-    Type *translateStructOrUnionOrEnum(const clang::QualType &qtpe);
+    std::shared_ptr<Type>
+    translateStructOrUnionOrEnum(const clang::QualType &qtpe);
 
-    Type *translateStructOrUnion(const clang::QualType &qtpe);
+    std::shared_ptr<Type> translateStructOrUnion(const clang::QualType &qtpe);
 
-    Type *translateFunctionPointer(const clang::QualType &qtpe,
-                                   const std::string *avoid);
+    std::shared_ptr<Type> translateFunctionPointer(const clang::QualType &qtpe,
+                                                   const std::string *avoid);
 
-    Type *translatePointer(const clang::QualType &pointee,
+    std::shared_ptr<Type> translatePointer(const clang::QualType &pointee,
+                                           const std::string *avoid);
+
+    std::shared_ptr<Type>
+    translateConstantArray(const clang::ConstantArrayType *ar,
                            const std::string *avoid);
-
-    Type *translateConstantArray(const clang::ConstantArrayType *ar,
-                                 const std::string *avoid);
 };

--- a/bindgen/defines/DefineFinder.cpp
+++ b/bindgen/defines/DefineFinder.cpp
@@ -42,8 +42,9 @@ void DefineFinder::MacroDefined(const clang::Token &macroNameTok,
             clang::Token stringToken = (*tokens)[0];
             std::string literal(stringToken.getLiteralData(),
                                 stringToken.getLength());
-            ir.addLiteralDefine(macroName, "c" + literal,
-                                new PrimitiveType("native.CString"));
+            ir.addLiteralDefine(
+                macroName, "c" + literal,
+                std::make_shared<PrimitiveType>("native.CString"));
         } else if (tokens->size() == 1 &&
                    (*tokens)[0].getKind() == clang::tok::identifier) {
             // token might be a variable
@@ -152,7 +153,8 @@ void DefineFinder::addNumericConstantDefine(const std::string &macroName,
         if (!positive) {
             scalaLiteral = "-" + scalaLiteral;
         }
-        ir.addLiteralDefine(macroName, scalaLiteral, new PrimitiveType(type));
+        ir.addLiteralDefine(macroName, scalaLiteral,
+                            std::make_shared<PrimitiveType>(type));
     }
 }
 

--- a/bindgen/ir/Enum.cpp
+++ b/bindgen/ir/Enum.cpp
@@ -14,9 +14,9 @@ Enum::Enum(std::string name, std::string type,
 
 bool Enum::isAnonymous() const { return name.empty(); }
 
-TypeDef *Enum::generateTypeDef() {
+std::shared_ptr<TypeDef> Enum::generateTypeDef() {
     assert(!isAnonymous());
-    return new TypeDef("enum_" + name, this);
+    return std::make_shared<TypeDef>("enum_" + name, shared_from_this());
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Enum &e) {
@@ -49,5 +49,3 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Enum &e) {
 }
 
 std::string Enum::getName() const { return name; }
-
-bool Enum::canBeDeallocated() const { return false; }

--- a/bindgen/ir/Enum.h
+++ b/bindgen/ir/Enum.h
@@ -18,20 +18,18 @@ class Enumerator {
     int64_t value;
 };
 
-class Enum : public PrimitiveType {
+class Enum : public PrimitiveType, public std::enable_shared_from_this<Enum> {
   public:
     Enum(std::string name, std::string type,
          std::vector<Enumerator> enumerators);
 
     bool isAnonymous() const;
 
-    TypeDef *generateTypeDef();
+    std::shared_ptr<TypeDef> generateTypeDef();
 
     std::string getName() const;
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Enum &e);
-
-    bool canBeDeallocated() const override;
 
   private:
     std::string name; // might be empty

--- a/bindgen/ir/Function.cpp
+++ b/bindgen/ir/Function.cpp
@@ -1,11 +1,11 @@
 #include "Function.h"
 #include "../Utils.h"
 
-Parameter::Parameter(std::string name, Type *type)
+Parameter::Parameter(std::string name, std::shared_ptr<Type> type)
     : TypeAndName(std::move(name), type) {}
 
 Function::Function(const std::string &name, std::vector<Parameter *> parameters,
-                   Type *retType, bool isVariadic)
+                   std::shared_ptr<Type> retType, bool isVariadic)
     : name(name), scalaName(name), parameters(std::move(parameters)),
       retType(retType), isVariadic(isVariadic) {}
 
@@ -29,7 +29,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Function &func) {
     return s;
 }
 
-bool Function::usesType(Type *type) const {
+bool Function::usesType(std::shared_ptr<Type> type) const {
     if (retType == type) {
         return true;
     }
@@ -63,16 +63,6 @@ bool Function::existsParameterWithName(const std::string &parameterName) const {
 
 void Function::setScalaName(std::string scalaName) {
     this->scalaName = std::move(scalaName);
-}
-
-void Function::deallocateTypesThatAreNotInIR() {
-    if (retType->canBeDeallocated()) {
-        delete retType;
-    }
-
-    for (const auto &parameter : parameters) {
-        parameter->deallocateTypesThatAreNotInIR();
-    }
 }
 
 Function::~Function() {

--- a/bindgen/ir/Function.h
+++ b/bindgen/ir/Function.h
@@ -8,26 +8,24 @@
 
 class Parameter : public TypeAndName {
   public:
-    Parameter(std::string name, Type *type);
+    Parameter(std::string name, std::shared_ptr<Type> type);
 };
 
 class Function {
   public:
     Function(const std::string &name, std::vector<Parameter *> parameters,
-             Type *retType, bool isVariadic);
+             std::shared_ptr<Type> retType, bool isVariadic);
 
     ~Function();
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const Function &func);
 
-    bool usesType(Type *type) const;
+    bool usesType(std::shared_ptr<Type> type) const;
 
     std::string getName() const;
 
     void setScalaName(std::string scalaName);
-
-    void deallocateTypesThatAreNotInIR();
 
   private:
     std::string getVarargsParameterName() const;
@@ -37,7 +35,7 @@ class Function {
     std::string name;      // real name of the function
     std::string scalaName; // not empty
     std::vector<Parameter *> parameters;
-    Type *retType;
+    std::shared_ptr<Type> retType;
     bool isVariadic;
 };
 

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -301,6 +301,7 @@ T IR::getDeclarationWithName(std::vector<T> &declarations,
             return declaration;
         }
     }
+    llvm::errs() << "Failed to get declaration for " << name << "\n";
     return nullptr;
 }
 

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -7,18 +7,19 @@ IR::IR(std::string libName, std::string linkName, std::string objectName,
       objectName(std::move(objectName)), packageName(std::move(packageName)) {}
 
 void IR::addFunction(std::string name, std::vector<Parameter *> parameters,
-                     Type *retType, bool isVariadic) {
-    functions.push_back(
-        new Function(name, std::move(parameters), retType, isVariadic));
+                     std::shared_ptr<Type> retType, bool isVariadic) {
+    functions.push_back(std::make_shared<Function>(name, std::move(parameters),
+                                                   retType, isVariadic));
 }
 
-void IR::addTypeDef(std::string name, Type *type) {
-    typeDefs.push_back(new TypeDef(std::move(name), type));
+void IR::addTypeDef(std::string name, std::shared_ptr<Type> type) {
+    typeDefs.push_back(std::make_shared<TypeDef>(std::move(name), type));
 }
 
-Type *IR::addEnum(std::string name, const std::string &type,
-                  std::vector<Enumerator> enumerators) {
-    Enum *e = new Enum(std::move(name), type, std::move(enumerators));
+std::shared_ptr<Type> IR::addEnum(std::string name, const std::string &type,
+                                  std::vector<Enumerator> enumerators) {
+    std::shared_ptr<Enum> e =
+        std::make_shared<Enum>(std::move(name), type, std::move(enumerators));
     enums.push_back(e);
     if (!e->isAnonymous()) {
         typeDefs.push_back(e->generateTypeDef());
@@ -27,34 +28,40 @@ Type *IR::addEnum(std::string name, const std::string &type,
     return nullptr;
 }
 
-Type *IR::addStruct(std::string name, std::vector<Field *> fields,
-                    uint64_t typeSize) {
-    Struct *s = new Struct(std::move(name), std::move(fields), typeSize);
+std::shared_ptr<Type> IR::addStruct(std::string name,
+                                    std::vector<Field *> fields,
+                                    uint64_t typeSize) {
+    std::shared_ptr<Struct> s =
+        std::make_shared<Struct>(std::move(name), std::move(fields), typeSize);
     structs.push_back(s);
     typeDefs.push_back(s->generateTypeDef());
     return typeDefs.back();
 }
 
-Type *IR::addUnion(std::string name, std::vector<Field *> fields,
-                   uint64_t maxSize) {
-    Union *u = new Union(std::move(name), std::move(fields), maxSize);
+std::shared_ptr<Type>
+IR::addUnion(std::string name, std::vector<Field *> fields, uint64_t maxSize) {
+    std::shared_ptr<Union> u =
+        std::make_shared<Union>(std::move(name), std::move(fields), maxSize);
     unions.push_back(u);
     typeDefs.push_back(u->generateTypeDef());
     return typeDefs.back();
 }
 
-void IR::addLiteralDefine(std::string name, std::string literal, Type *type) {
-    literalDefines.push_back(
-        new LiteralDefine(std::move(name), std::move(literal), type));
+void IR::addLiteralDefine(std::string name, std::string literal,
+                          std::shared_ptr<Type> type) {
+    literalDefines.push_back(std::make_shared<LiteralDefine>(
+        std::move(name), std::move(literal), type));
 }
 
 void IR::addPossibleVarDefine(const std::string &macroName,
                               const std::string &varName) {
-    possibleVarDefines.push_back(new PossibleVarDefine(macroName, varName));
+    possibleVarDefines.push_back(
+        std::make_shared<PossibleVarDefine>(macroName, varName));
 }
 
-void IR::addVarDefine(std::string name, Variable *variable) {
-    varDefines.push_back(new VarDefine(std::move(name), variable));
+void IR::addVarDefine(std::string name, std::shared_ptr<Variable> variable) {
+    varDefines.push_back(
+        std::make_shared<VarDefine>(std::move(name), variable));
 }
 
 bool IR::libObjEmpty() const {
@@ -181,7 +188,7 @@ void IR::filterDeclarations(const std::string &excludePrefix) {
 
 void IR::filterTypeDefs(const std::string &excludePrefix) {
     for (auto it = typeDefs.begin(); it != typeDefs.end();) {
-        TypeDef *typeDef = *it;
+        std::shared_ptr<TypeDef> typeDef = *it;
         if (startsWith(typeDef->getName(), excludePrefix) &&
             typeIsUsedOnlyInTypeDefs(typeDef)) {
             /* remove this typedef and replace aliases with actual type */
@@ -193,7 +200,8 @@ void IR::filterTypeDefs(const std::string &excludePrefix) {
     }
 }
 
-void IR::replaceTypeInTypeDefs(Type *oldType, Type *newType) {
+void IR::replaceTypeInTypeDefs(std::shared_ptr<Type> oldType,
+                               std::shared_ptr<Type> newType) {
     for (auto &typeDef : typeDefs) {
         if (typeDef->getType() == oldType) {
             typeDef->setType(newType);
@@ -202,7 +210,8 @@ void IR::replaceTypeInTypeDefs(Type *oldType, Type *newType) {
 }
 
 template <typename T>
-bool IR::isTypeUsed(const std::vector<T> &declarations, Type *type) {
+bool IR::isTypeUsed(const std::vector<T> &declarations,
+                    std::shared_ptr<Type> type) {
     for (const auto decl : declarations) {
         if (decl->usesType(type)) {
             return true;
@@ -211,7 +220,7 @@ bool IR::isTypeUsed(const std::vector<T> &declarations, Type *type) {
     return false;
 }
 
-bool IR::typeIsUsedOnlyInTypeDefs(Type *type) {
+bool IR::typeIsUsedOnlyInTypeDefs(std::shared_ptr<Type> type) {
     return !(isTypeUsed(functions, type) || isTypeUsed(structs, type) ||
              isTypeUsed(unions, type));
 }
@@ -281,13 +290,14 @@ std::string IR::getDefineForVar(const std::string &varName) const {
     return "";
 }
 
-Variable *IR::addVariable(const std::string &name, Type *type) {
-    Variable *variable = new Variable(name, type);
+std::shared_ptr<Variable> IR::addVariable(const std::string &name,
+                                          std::shared_ptr<Type> type) {
+    std::shared_ptr<Variable> variable = std::make_shared<Variable>(name, type);
     variables.push_back(variable);
     return variable;
 }
 
-TypeDef *IR::getTypeDefWithName(const std::string &name) {
+std::shared_ptr<TypeDef> IR::getTypeDefWithName(const std::string &name) {
     return getDeclarationWithName(typeDefs, name);
 }
 
@@ -306,31 +316,13 @@ T IR::getDeclarationWithName(std::vector<T> &declarations,
 }
 
 IR::~IR() {
-    deallocateTypesThatAreNotInIR(functions);
-    deallocateTypesThatAreNotInIR(typeDefs);
-    deallocateTypesThatAreNotInIR(structs);
-    deallocateTypesThatAreNotInIR(unions);
-    deallocateTypesThatAreNotInIR(variables);
-
-    clearVector(functions);
-    clearVector(typeDefs);
-    clearVector(structs);
-    clearVector(unions);
-    clearVector(enums);
-    clearVector(literalDefines);
-    clearVector(possibleVarDefines);
-    clearVector(variables);
-    clearVector(varDefines);
-}
-
-template <typename T> void IR::clearVector(std::vector<T> v) {
-    for (const auto &e : v) {
-        delete e;
-    }
-}
-
-template <typename T> void IR::deallocateTypesThatAreNotInIR(std::vector<T> v) {
-    for (const auto &e : v) {
-        e->deallocateTypesThatAreNotInIR();
-    }
+    functions.clear();
+    typeDefs.clear();
+    structs.clear();
+    unions.clear();
+    enums.clear();
+    literalDefines.clear();
+    possibleVarDefines.clear();
+    variables.clear();
+    varDefines.clear();
 }

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -20,36 +20,38 @@ class IR {
     ~IR();
 
     void addFunction(std::string name, std::vector<Parameter *> parameters,
-                     Type *retType, bool isVariadic);
+                     std::shared_ptr<Type> retType, bool isVariadic);
 
-    void addTypeDef(std::string name, Type *type);
+    void addTypeDef(std::string name, std::shared_ptr<Type> type);
 
     /**
      * @return type alias for the enum
      */
-    Type *addEnum(std::string name, const std::string &type,
-                  std::vector<Enumerator> enumerators);
+    std::shared_ptr<Type> addEnum(std::string name, const std::string &type,
+                                  std::vector<Enumerator> enumerators);
 
     /**
      * @return type alias for the struct
      */
-    Type *addStruct(std::string name, std::vector<Field *> fields,
-                    uint64_t typeSize);
+    std::shared_ptr<Type>
+    addStruct(std::string name, std::vector<Field *> fields, uint64_t typeSize);
 
     /**
      * @return type alias for the union
      */
-    Type *addUnion(std::string name, std::vector<Field *> fields,
-                   uint64_t maxSize);
+    std::shared_ptr<Type>
+    addUnion(std::string name, std::vector<Field *> fields, uint64_t maxSize);
 
-    void addLiteralDefine(std::string name, std::string literal, Type *type);
+    void addLiteralDefine(std::string name, std::string literal,
+                          std::shared_ptr<Type> type);
 
     void addPossibleVarDefine(const std::string &macroName,
                               const std::string &varName);
 
-    void addVarDefine(std::string name, Variable *variable);
+    void addVarDefine(std::string name, std::shared_ptr<Variable> variable);
 
-    Variable *addVariable(const std::string &name, Type *type);
+    std::shared_ptr<Variable> addVariable(const std::string &name,
+                                          std::shared_ptr<Type> type);
 
     /**
      * @return true if there are no functions, types,
@@ -69,7 +71,7 @@ class IR {
      */
     std::string getDefineForVar(const std::string &varName) const;
 
-    TypeDef *getTypeDefWithName(const std::string &name);
+    std::shared_ptr<TypeDef> getTypeDefWithName(const std::string &name);
 
   private:
     /**
@@ -106,18 +108,20 @@ class IR {
     /**
      * Find all typedefs that use oldType and replace it with newType.
      */
-    void replaceTypeInTypeDefs(Type *oldType, Type *newType);
+    void replaceTypeInTypeDefs(std::shared_ptr<Type> oldType,
+                               std::shared_ptr<Type> newType);
 
     /**
      * @return true if given type is used only in typedefs.
      */
-    bool typeIsUsedOnlyInTypeDefs(Type *type);
+    bool typeIsUsedOnlyInTypeDefs(std::shared_ptr<Type> type);
 
     /**
      * @return true if type is used in one of given declarations.
      */
     template <typename T>
-    bool isTypeUsed(const std::vector<T> &declarations, Type *type);
+    bool isTypeUsed(const std::vector<T> &declarations,
+                    std::shared_ptr<Type> type);
 
     void setScalaNames();
 
@@ -136,20 +140,18 @@ class IR {
 
     template <typename T> void clearVector(std::vector<T> v);
 
-    template <typename T> void deallocateTypesThatAreNotInIR(std::vector<T> v);
-
     std::string libName;    // name of the library
     std::string linkName;   // name of the library to link with
     std::string objectName; // name of Scala object
-    std::vector<Function *> functions;
-    std::vector<TypeDef *> typeDefs;
-    std::vector<Struct *> structs;
-    std::vector<Union *> unions;
-    std::vector<Enum *> enums;
-    std::vector<LiteralDefine *> literalDefines;
-    std::vector<PossibleVarDefine *> possibleVarDefines;
-    std::vector<VarDefine *> varDefines;
-    std::vector<Variable *> variables;
+    std::vector<std::shared_ptr<Function>> functions;
+    std::vector<std::shared_ptr<TypeDef>> typeDefs;
+    std::vector<std::shared_ptr<Struct>> structs;
+    std::vector<std::shared_ptr<Union>> unions;
+    std::vector<std::shared_ptr<Enum>> enums;
+    std::vector<std::shared_ptr<LiteralDefine>> literalDefines;
+    std::vector<std::shared_ptr<PossibleVarDefine>> possibleVarDefines;
+    std::vector<std::shared_ptr<VarDefine>> varDefines;
+    std::vector<std::shared_ptr<Variable>> variables;
     bool generated = false; // generate type defs only once
     std::string packageName;
 };

--- a/bindgen/ir/LiteralDefine.cpp
+++ b/bindgen/ir/LiteralDefine.cpp
@@ -1,6 +1,7 @@
 #include "LiteralDefine.h"
 
-LiteralDefine::LiteralDefine(std::string name, std::string literal, Type *type)
+LiteralDefine::LiteralDefine(std::string name, std::string literal,
+                             std::shared_ptr<Type> type)
     : Define(std::move(name)), literal(std::move(literal)), type(type) {}
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
@@ -8,10 +9,4 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
     s << "  val " << literalDefine.name << ": " << literalDefine.type->str()
       << " = " << literalDefine.literal << "\n";
     return s;
-}
-
-void LiteralDefine::deallocateTypesThatAreNotInIR() {
-    if (type->canBeDeallocated()) {
-        delete type;
-    }
 }

--- a/bindgen/ir/LiteralDefine.h
+++ b/bindgen/ir/LiteralDefine.h
@@ -7,16 +7,15 @@
 
 class LiteralDefine : public Define {
   public:
-    LiteralDefine(std::string name, std::string literal, Type *type);
+    LiteralDefine(std::string name, std::string literal,
+                  std::shared_ptr<Type> type);
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const LiteralDefine &literalDefine);
 
-    void deallocateTypesThatAreNotInIR();
-
   private:
     std::string literal;
-    Type *type;
+    std::shared_ptr<Type> type;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_LITERALDEFINE_H

--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -11,7 +11,7 @@
 
 class Field : public TypeAndName {
   public:
-    Field(std::string name, Type *type);
+    Field(std::string name, std::shared_ptr<Type> type);
 };
 
 class StructOrUnion {
@@ -20,24 +20,24 @@ class StructOrUnion {
 
     ~StructOrUnion();
 
-    virtual TypeDef *generateTypeDef() = 0;
+    virtual std::shared_ptr<TypeDef> generateTypeDef() = 0;
 
     virtual std::string generateHelperClass() const = 0;
 
     std::string getName() const;
-
-    void deallocateTypesThatAreNotInIR();
 
   protected:
     std::string name;
     std::vector<Field *> fields;
 };
 
-class Struct : public StructOrUnion, public Type {
+class Struct : public StructOrUnion,
+               public Type,
+               public std::enable_shared_from_this<Struct> {
   public:
     Struct(std::string name, std::vector<Field *> fields, uint64_t typeSize);
 
-    TypeDef *generateTypeDef() override;
+    std::shared_ptr<TypeDef> generateTypeDef() override;
 
     std::string generateHelperClass() const override;
 
@@ -48,26 +48,24 @@ class Struct : public StructOrUnion, public Type {
      */
     bool hasHelperMethods() const;
 
-    bool usesType(Type *type) const override;
+    bool usesType(std::shared_ptr<Type> type) const override;
 
     std::string str() const override;
-
-    bool canBeDeallocated() const override;
 
   private:
     /* type size is needed if number of fields is bigger than 22 */
     uint64_t typeSize;
 };
 
-class Union : public StructOrUnion, public ArrayType {
+class Union : public StructOrUnion,
+              public ArrayType,
+              public std::enable_shared_from_this<Union> {
   public:
     Union(std::string name, std::vector<Field *> fields, uint64_t maxSize);
 
-    TypeDef *generateTypeDef() override;
+    std::shared_ptr<TypeDef> generateTypeDef() override;
 
     std::string generateHelperClass() const override;
-
-    bool canBeDeallocated() const override;
 
   private:
     std::string getTypeAlias() const;

--- a/bindgen/ir/TypeAndName.cpp
+++ b/bindgen/ir/TypeAndName.cpp
@@ -1,16 +1,11 @@
 #include "TypeAndName.h"
+#include <clang/Tooling/Tooling.h>
 
-TypeAndName::TypeAndName(std::string name, Type *type)
+TypeAndName::TypeAndName(std::string name, std::shared_ptr<Type> type)
     : name(std::move(name)), type(type) {}
 
-Type *TypeAndName::getType() const { return type; }
+std::shared_ptr<Type> TypeAndName::getType() const { return type; }
 
 std::string TypeAndName::getName() const { return name; }
 
-void TypeAndName::setType(Type *type) { this->type = type; }
-
-void TypeAndName::deallocateTypesThatAreNotInIR() {
-    if (type->canBeDeallocated()) {
-        delete type;
-    }
-}
+void TypeAndName::setType(std::shared_ptr<Type> type) { this->type = type; }

--- a/bindgen/ir/TypeAndName.h
+++ b/bindgen/ir/TypeAndName.h
@@ -2,6 +2,7 @@
 #define SCALA_NATIVE_BINDGEN_TYPEANDNAME_H
 
 #include "types/Type.h"
+#include <memory>
 #include <string>
 
 /**
@@ -10,19 +11,17 @@
  */
 class TypeAndName {
   public:
-    TypeAndName(std::string name, Type *type);
+    TypeAndName(std::string name, std::shared_ptr<Type> type);
 
-    Type *getType() const;
+    std::shared_ptr<Type> getType() const;
 
-    void setType(Type *name);
+    void setType(std::shared_ptr<Type> name);
 
     std::string getName() const;
 
-    void deallocateTypesThatAreNotInIR();
-
   protected:
     std::string name;
-    Type *type;
+    std::shared_ptr<Type> type;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_TYPEANDNAME_H

--- a/bindgen/ir/TypeDef.cpp
+++ b/bindgen/ir/TypeDef.cpp
@@ -1,7 +1,7 @@
 #include "TypeDef.h"
 #include "../Utils.h"
 
-TypeDef::TypeDef(std::string name, Type *type)
+TypeDef::TypeDef(std::string name, std::shared_ptr<Type> type)
     : TypeAndName(std::move(name), type) {}
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const TypeDef &typeDef) {
@@ -10,10 +10,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const TypeDef &typeDef) {
     return s;
 }
 
-bool TypeDef::usesType(Type *type) const {
-    return this == type || this->type == type;
+bool TypeDef::usesType(std::shared_ptr<Type> type) const {
+    return this == type.get() || this->type == type;
 }
 
 std::string TypeDef::str() const { return handleReservedWords(name); }
-
-bool TypeDef::canBeDeallocated() const { return false; }

--- a/bindgen/ir/TypeDef.h
+++ b/bindgen/ir/TypeDef.h
@@ -7,16 +7,14 @@
 
 class TypeDef : public TypeAndName, public Type {
   public:
-    TypeDef(std::string name, Type *type);
+    TypeDef(std::string name, std::shared_ptr<Type> type);
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const TypeDef &type);
 
-    bool usesType(Type *type) const override;
+    bool usesType(std::shared_ptr<Type> type) const override;
 
     std::string str() const override;
-
-    bool canBeDeallocated() const override;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_TYPEDEF_H

--- a/bindgen/ir/VarDefine.cpp
+++ b/bindgen/ir/VarDefine.cpp
@@ -1,6 +1,6 @@
 #include "VarDefine.h"
 
-VarDefine::VarDefine(std::string name, Variable *variable)
+VarDefine::VarDefine(std::string name, std::shared_ptr<Variable> variable)
     : Define(std::move(name)), variable(variable) {}
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s,

--- a/bindgen/ir/VarDefine.h
+++ b/bindgen/ir/VarDefine.h
@@ -10,13 +10,13 @@
  */
 class VarDefine : public Define {
   public:
-    VarDefine(std::string name, Variable *variable);
+    VarDefine(std::string name, std::shared_ptr<Variable> variable);
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const VarDefine &varDefine);
 
   private:
-    Variable *variable;
+    std::shared_ptr<Variable> variable;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_VARDEFINE_H

--- a/bindgen/ir/Variable.cpp
+++ b/bindgen/ir/Variable.cpp
@@ -1,4 +1,4 @@
 #include "Variable.h"
 
-Variable::Variable(const std::string &name, Type *type)
+Variable::Variable(const std::string &name, std::shared_ptr<Type> type)
     : TypeAndName(name, type) {}

--- a/bindgen/ir/Variable.h
+++ b/bindgen/ir/Variable.h
@@ -5,7 +5,7 @@
 
 class Variable : public TypeAndName {
   public:
-    Variable(const std::string &name, Type *type);
+    Variable(const std::string &name, std::shared_ptr<Type> type);
 };
 
 #endif // SCALA_NATIVE_BINDGEN_VARIABLE_H

--- a/bindgen/ir/types/ArrayType.cpp
+++ b/bindgen/ir/types/ArrayType.cpp
@@ -1,7 +1,7 @@
 #include "ArrayType.h"
 #include "../../Utils.h"
 
-ArrayType::ArrayType(Type *elementsType, uint64_t size)
+ArrayType::ArrayType(std::shared_ptr<Type> elementsType, uint64_t size)
     : size(size), elementsType(elementsType) {}
 
 std::string ArrayType::str() const {
@@ -9,12 +9,8 @@ std::string ArrayType::str() const {
            uint64ToScalaNat(size) + "]";
 }
 
-bool ArrayType::usesType(Type *type) const {
-    return this == type || elementsType == type;
+bool ArrayType::usesType(std::shared_ptr<Type> type) const {
+    return this == type.get() || elementsType == type;
 }
 
-ArrayType::~ArrayType() {
-    if (elementsType->canBeDeallocated()) {
-        delete elementsType;
-    }
-}
+ArrayType::~ArrayType() {}

--- a/bindgen/ir/types/ArrayType.h
+++ b/bindgen/ir/types/ArrayType.h
@@ -5,17 +5,17 @@
 
 class ArrayType : public Type {
   public:
-    ArrayType(Type *elementsType, uint64_t size);
+    ArrayType(std::shared_ptr<Type> elementsType, uint64_t size);
 
     ~ArrayType() override;
 
-    bool usesType(Type *type) const override;
+    bool usesType(std::shared_ptr<Type> type) const override;
 
     std::string str() const override;
 
   private:
     const uint64_t size;
-    Type *elementsType;
+    std::shared_ptr<Type> elementsType;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_ARRAYTYPE_H

--- a/bindgen/ir/types/FunctionPointerType.cpp
+++ b/bindgen/ir/types/FunctionPointerType.cpp
@@ -2,8 +2,8 @@
 #include <sstream>
 
 FunctionPointerType::FunctionPointerType(
-    Type *returnType, const std::vector<Type *> &parametersTypes,
-    bool isVariadic)
+    std::shared_ptr<Type> returnType,
+    const std::vector<std::shared_ptr<Type>> &parametersTypes, bool isVariadic)
     : returnType(returnType), parametersTypes(parametersTypes),
       isVariadic(isVariadic) {}
 
@@ -22,8 +22,8 @@ std::string FunctionPointerType::str() const {
     return ss.str();
 }
 
-bool FunctionPointerType::usesType(Type *type) const {
-    if (this == type) {
+bool FunctionPointerType::usesType(std::shared_ptr<Type> type) const {
+    if (this == type.get()) {
         return true;
     }
     if (returnType == type) {
@@ -38,13 +38,4 @@ bool FunctionPointerType::usesType(Type *type) const {
     return false;
 }
 
-FunctionPointerType::~FunctionPointerType() {
-    if (returnType->canBeDeallocated()) {
-        delete returnType;
-    }
-    for (const auto &parameterType : parametersTypes) {
-        if (parameterType->canBeDeallocated()) {
-            delete parameterType;
-        }
-    }
-}
+FunctionPointerType::~FunctionPointerType() {}

--- a/bindgen/ir/types/FunctionPointerType.h
+++ b/bindgen/ir/types/FunctionPointerType.h
@@ -6,19 +6,20 @@
 
 class FunctionPointerType : public Type {
   public:
-    FunctionPointerType(Type *returnType,
-                        const std::vector<Type *> &parametersTypes,
-                        bool isVariadic);
+    FunctionPointerType(
+        std::shared_ptr<Type> returnType,
+        const std::vector<std::shared_ptr<Type>> &parametersTypes,
+        bool isVariadic);
 
     ~FunctionPointerType() override;
 
-    bool usesType(Type *type) const override;
+    bool usesType(std::shared_ptr<Type> type) const override;
 
     std::string str() const override;
 
   private:
-    Type *returnType;
-    std::vector<Type *> parametersTypes;
+    std::shared_ptr<Type> returnType;
+    std::vector<std::shared_ptr<Type>> parametersTypes;
     bool isVariadic;
 };
 

--- a/bindgen/ir/types/PointerType.cpp
+++ b/bindgen/ir/types/PointerType.cpp
@@ -1,20 +1,16 @@
 #include "PointerType.h"
 
-PointerType::PointerType(Type *type) : type(type) {}
+PointerType::PointerType(std::shared_ptr<Type> type) : type(type) {}
 
 std::string PointerType::str() const {
     return "native.Ptr[" + type->str() + "]";
 }
 
-bool PointerType::usesType(Type *type) const {
-    if (this == type) {
+bool PointerType::usesType(std::shared_ptr<Type> type) const {
+    if (this == type.get()) {
         return true;
     }
     return this->type == type;
 }
 
-PointerType::~PointerType() {
-    if (type->canBeDeallocated()) {
-        delete type;
-    }
-}
+PointerType::~PointerType() {}

--- a/bindgen/ir/types/PointerType.h
+++ b/bindgen/ir/types/PointerType.h
@@ -5,16 +5,16 @@
 
 class PointerType : public Type {
   public:
-    explicit PointerType(Type *type);
+    explicit PointerType(std::shared_ptr<Type> type);
 
     ~PointerType() override;
 
-    bool usesType(Type *type) const override;
+    bool usesType(std::shared_ptr<Type> type) const override;
 
     std::string str() const override;
 
   private:
-    Type *type;
+    std::shared_ptr<Type> type;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_POINTERTYPE_H

--- a/bindgen/ir/types/PrimitiveType.cpp
+++ b/bindgen/ir/types/PrimitiveType.cpp
@@ -7,8 +7,8 @@ std::string PrimitiveType::str() const { return handleReservedWords(type); }
 
 std::string PrimitiveType::getType() const { return type; }
 
-bool PrimitiveType::usesType(Type *type) const {
-    if (this == type) {
+bool PrimitiveType::usesType(std::shared_ptr<Type> type) const {
+    if (this == type.get()) {
         return true;
     }
     return str() == type->str();

--- a/bindgen/ir/types/PrimitiveType.h
+++ b/bindgen/ir/types/PrimitiveType.h
@@ -13,7 +13,7 @@ class PrimitiveType : public Type {
 
     std::string getType() const;
 
-    bool usesType(Type *type) const override;
+    bool usesType(std::shared_ptr<Type> type) const override;
 
     std::string str() const override;
 

--- a/bindgen/ir/types/Type.cpp
+++ b/bindgen/ir/types/Type.cpp
@@ -2,8 +2,6 @@
 
 std::string Type::str() const { return ""; }
 
-bool Type::usesType(Type *type) const { return false; }
-
-bool Type::canBeDeallocated() const { return true; }
+bool Type::usesType(std::shared_ptr<Type> type) const { return false; }
 
 Type::~Type() = default;

--- a/bindgen/ir/types/Type.h
+++ b/bindgen/ir/types/Type.h
@@ -1,6 +1,7 @@
 #ifndef SCALA_NATIVE_BINDGEN_TYPE_H
 #define SCALA_NATIVE_BINDGEN_TYPE_H
 
+#include <memory>
 #include <string>
 
 /**
@@ -12,16 +13,7 @@ class Type {
 
     virtual std::string str() const;
 
-    virtual bool usesType(Type *type) const;
-
-    /**
-     * Instances of Enum, Struct, Union and TypeDef are stored in IR so they are
-     * deallocated in IR destructor.
-     * All other instances of Type are *not* shared between multiple objects and
-     * can be deallocated in containing object.
-     * @return true if instance can be deallocated.
-     */
-    virtual bool canBeDeallocated() const;
+    virtual bool usesType(std::shared_ptr<Type> type) const;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_TYPE_H


### PR DESCRIPTION
Adds a workaround for `translateConstantArray()` to return a dummy `new PrimitiveType("Byte")` when the type cannot be resolved. This happens for certain internal types:

```
Failed to get declaration for struct __va_list_tag
Failed to translate array type struct __va_list_tag
Failed to get declaration for struct __va_list_tag
Failed to translate array type struct __va_list_tag
Failed to get declaration for struct __darwin_pthread_handler_rec
```

Before the type-in-IR PR `__darwin_pthread_handler_rec` was flagged as cyclic:

```
Error: struct___darwin_pthread_handler_rec is cyclic
struct___darwin_pthread_handler_rec
	Unit
	struct___darwin_pthread_handler_rec
	void (void *)
```

and `struct __va_list_tag` was used without being defined:
```
type __darwin_va_list = native.CArray[struct___va_list_tag, native.Nat._1]
```