### PR TITLE
Handle opaque types

### DIFF
--- a/bindgen/TypeTranslator.cpp
+++ b/bindgen/TypeTranslator.cpp
@@ -87,22 +87,22 @@ TypeTranslator::translatePointer(const clang::QualType &pte,
 std::shared_ptr<Type>
 TypeTranslator::translateStructOrUnionOrEnum(const clang::QualType &qtpe) {
     std::string name = qtpe.getUnqualifiedType().getAsString();
+    std::string nameWithoutSpace = replaceChar(name, " ", "_");
 
-    auto it = aliasesMap.find(name);
-    if (it != aliasesMap.end()) {
-        /* name contains space: struct <name>.
-         * Use type alias instead struct type */
-        return (*it).second;
-    }
-    std::shared_ptr<TypeDef> typeDef = ir.getTypeDefWithName(name);
+    /* If the struct was already declared then there is a TypeDef instance
+     * with appropriate name.
+     *
+     * If there is no such TypeDef then the type is opaque and TypeDef with
+     * nullptr will be generated for the type. */
+
+    std::shared_ptr<TypeDef> typeDef = ir.getTypeDefWithName(nameWithoutSpace);
     if (typeDef) {
-        /* type has typedef alias */
         return typeDef;
     }
     /* type is not yet defined.
-     * nullptr will be replaced by actual type */
-    typeDef = ir.addTypeDef(replaceChar(name, " ", "_"), nullptr);
-    addAlias(name, typeDef);
+     * TypeDef with nullptr will be created.
+     * nullptr will be replaced by actual type when the type is declared. */
+    typeDef = ir.addTypeDef(nameWithoutSpace, nullptr);
     return typeDef;
 }
 
@@ -182,10 +182,6 @@ std::shared_ptr<Type> TypeTranslator::translate(const clang::QualType &qtpe,
                 qtpe.getUnqualifiedType().getAsString());
         }
     }
-}
-
-void TypeTranslator::addAlias(std::string cName, std::shared_ptr<Type> type) {
-    aliasesMap[cName] = type;
 }
 
 std::string TypeTranslator::getTypeFromTypeMap(std::string cType) {

--- a/bindgen/TypeTranslator.h
+++ b/bindgen/TypeTranslator.h
@@ -17,8 +17,6 @@ class TypeTranslator {
     std::shared_ptr<Type> translate(const clang::QualType &tpe,
                                     const std::string * = nullptr);
 
-    void addAlias(std::string cName, std::shared_ptr<Type> type);
-
     std::string getTypeFromTypeMap(std::string cType);
 
   private:
@@ -29,11 +27,6 @@ class TypeTranslator {
      * Primitive types
      */
     std::map<std::string, std::string> typeMap;
-
-    /**
-     * Maps C struct, union or enum name to Type alias
-     */
-    std::map<std::string, std::shared_ptr<Type>> aliasesMap;
 
     std::shared_ptr<Type>
     translateStructOrUnionOrEnum(const clang::QualType &qtpe);

--- a/bindgen/TypeTranslator.h
+++ b/bindgen/TypeTranslator.h
@@ -12,7 +12,7 @@ class TypeTranslator {
      * @param tpe The type to translate
      * @param avoid A type to avoid, useful to avoid cyclic definitions inside
      * structs, unions, ...
-     * @return the type translated
+     * @return the type translated or nullptr if type is function type.
      */
     std::shared_ptr<Type> translate(const clang::QualType &tpe,
                                     const std::string * = nullptr);

--- a/bindgen/Utils.h
+++ b/bindgen/Utils.h
@@ -100,13 +100,14 @@ template <typename T, typename PT> static inline bool isInstanceOf(PT *type) {
     return p != nullptr;
 }
 
-static inline std::string replaceChar(std::string str, const std::string &c1,
+static inline std::string replaceChar(const std::string &str,
+                                      const std::string &c1,
                                       const std::string &c2) {
     auto f = str.find(c1);
     if (f != std::string::npos) {
-        return str.replace(f, c1.length(), c2);
+        return std::string(str).replace(f, c1.length(), c2);
     }
-    return str;
+    return std::string(str);
 }
 
 #endif // UTILS_H

--- a/bindgen/Utils.h
+++ b/bindgen/Utils.h
@@ -109,6 +109,7 @@ static inline std::string replaceChar(const std::string &str,
         return std::string(str).replace(f, c1.length(), c2);
     }
     return std::string(str);
+}
 
 /**
  * Types may be wrapper in a chain of typedefs.

--- a/bindgen/Utils.h
+++ b/bindgen/Utils.h
@@ -100,4 +100,13 @@ template <typename T, typename PT> static inline bool isInstanceOf(PT *type) {
     return p != nullptr;
 }
 
+static inline std::string replaceChar(std::string str, const std::string &c1,
+                                      const std::string &c2) {
+    auto f = str.find(c1);
+    if (f != std::string::npos) {
+        return str.replace(f, c1.length(), c2);
+    }
+    return str;
+}
+
 #endif // UTILS_H

--- a/bindgen/ir/Function.cpp
+++ b/bindgen/ir/Function.cpp
@@ -7,7 +7,7 @@ Parameter::Parameter(std::string name, std::shared_ptr<Type> type)
 Function::Function(const std::string &name, std::vector<Parameter *> parameters,
                    std::shared_ptr<Type> retType, bool isVariadic)
     : name(name), scalaName(name), parameters(std::move(parameters)),
-      retType(retType), isVariadic(isVariadic) {}
+      retType(std::move(retType)), isVariadic(isVariadic) {}
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Function &func) {
     if (func.scalaName != func.name) {

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -30,39 +30,32 @@ std::shared_ptr<Type> IR::addEnum(std::string name, const std::string &type,
     return nullptr;
 }
 
-std::shared_ptr<Type> IR::addStruct(std::string name,
-                                    std::vector<Field *> fields,
-                                    uint64_t typeSize) {
-    std::shared_ptr<Struct> s =
-        std::make_shared<Struct>(std::move(name), std::move(fields), typeSize);
-    structs.push_back(s);
-    typeDefs.push_back(s->generateTypeDef());
-    return typeDefs.back();
-}
-
 void IR::addStruct(std::string name, std::vector<Field *> fields,
-                   uint64_t typeSize, const std::shared_ptr<TypeDef> &typeDef) {
+                   uint64_t typeSize) {
     std::shared_ptr<Struct> s =
-        std::make_shared<Struct>(std::move(name), std::move(fields), typeSize);
+        std::make_shared<Struct>(name, std::move(fields), typeSize);
     structs.push_back(s);
-    typeDef.get()->setType(s);
-}
-
-std::shared_ptr<Type>
-IR::addUnion(std::string name, std::vector<Field *> fields, uint64_t maxSize) {
-    std::shared_ptr<Union> u =
-        std::make_shared<Union>(std::move(name), std::move(fields), maxSize);
-    unions.push_back(u);
-    typeDefs.push_back(u->generateTypeDef());
-    return typeDefs.back();
+    std::shared_ptr<TypeDef> typeDef = getTypeDefWithName("struct_" + name);
+    if (typeDef) {
+        /* the struct type used to be opaque type, typeDef contains nullptr */
+        typeDef.get()->setType(s);
+    } else {
+        typeDefs.push_back(s->generateTypeDef());
+    }
 }
 
 void IR::addUnion(std::string name, std::vector<Field *> fields,
-                  uint64_t maxSize, const std::shared_ptr<TypeDef> &typeDef) {
+                  uint64_t maxSize) {
     std::shared_ptr<Union> u =
-        std::make_shared<Union>(std::move(name), std::move(fields), maxSize);
+        std::make_shared<Union>(name, std::move(fields), maxSize);
     unions.push_back(u);
-    typeDef.get()->setType(u);
+    std::shared_ptr<TypeDef> typeDef = getTypeDefWithName("union_" + name);
+    if (typeDef) {
+        /* the union type used to be opaque type, typeDef contains nullptr */
+        typeDef.get()->setType(u);
+    } else {
+        typeDefs.push_back(u->generateTypeDef());
+    }
 }
 
 void IR::addLiteralDefine(std::string name, std::string literal,

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -322,6 +322,11 @@ std::shared_ptr<Variable> IR::addVariable(const std::string &name,
 }
 
 std::shared_ptr<TypeDef> IR::getTypeDefWithName(const std::string &name) {
+    /* nullptr is returned in 2 cases:
+     * 1. TypeTranslator translates opaque struct/union type for which TypeDef
+     *    was not created.
+     * 2. TreeVisitor visits struct/union declaration and it checks whether a
+     *    TypeDef already exists for it.*/
     return getDeclarationWithName(typeDefs, name);
 }
 

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -12,8 +12,10 @@ void IR::addFunction(std::string name, std::vector<Parameter *> parameters,
                                                    retType, isVariadic));
 }
 
-void IR::addTypeDef(std::string name, std::shared_ptr<Type> type) {
+std::shared_ptr<TypeDef> IR::addTypeDef(std::string name,
+                                        std::shared_ptr<Type> type) {
     typeDefs.push_back(std::make_shared<TypeDef>(std::move(name), type));
+    return typeDefs.back();
 }
 
 std::shared_ptr<Type> IR::addEnum(std::string name, const std::string &type,
@@ -38,6 +40,14 @@ std::shared_ptr<Type> IR::addStruct(std::string name,
     return typeDefs.back();
 }
 
+void IR::addStruct(std::string name, std::vector<Field *> fields,
+                   uint64_t typeSize, const std::shared_ptr<TypeDef> &typeDef) {
+    std::shared_ptr<Struct> s =
+        std::make_shared<Struct>(std::move(name), std::move(fields), typeSize);
+    structs.push_back(s);
+    typeDef.get()->setType(s);
+}
+
 std::shared_ptr<Type>
 IR::addUnion(std::string name, std::vector<Field *> fields, uint64_t maxSize) {
     std::shared_ptr<Union> u =
@@ -45,6 +55,14 @@ IR::addUnion(std::string name, std::vector<Field *> fields, uint64_t maxSize) {
     unions.push_back(u);
     typeDefs.push_back(u->generateTypeDef());
     return typeDefs.back();
+}
+
+void IR::addUnion(std::string name, std::vector<Field *> fields,
+                  uint64_t maxSize, const std::shared_ptr<TypeDef> &typeDef) {
+    std::shared_ptr<Union> u =
+        std::make_shared<Union>(std::move(name), std::move(fields), maxSize);
+    unions.push_back(u);
+    typeDef.get()->setType(u);
 }
 
 void IR::addLiteralDefine(std::string name, std::string literal,
@@ -317,7 +335,6 @@ T IR::getDeclarationWithName(std::vector<T> &declarations,
             return declaration;
         }
     }
-    llvm::errs() << "Failed to get declaration for " << name << "\n";
     return nullptr;
 }
 

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -31,29 +31,11 @@ class IR {
     std::shared_ptr<Type> addEnum(std::string name, const std::string &type,
                                   std::vector<Enumerator> enumerators);
 
-    /**
-     * @return type alias for the struct
-     */
-    std::shared_ptr<Type>
-    addStruct(std::string name, std::vector<Field *> fields, uint64_t typeSize);
-
-    /**
-     * Add struct for which TypeDef already exists
-     */
     void addStruct(std::string name, std::vector<Field *> fields,
-                   uint64_t typeSize, const std::shared_ptr<TypeDef> &typeDef);
+                   uint64_t typeSize);
 
-    /**
-     * @return type alias for the union
-     */
-    std::shared_ptr<Type>
-    addUnion(std::string name, std::vector<Field *> fields, uint64_t maxSize);
-
-    /**
-     * Add union for which TypeDef already exists
-     */
     void addUnion(std::string name, std::vector<Field *> fields,
-                  uint64_t maxSize, const std::shared_ptr<TypeDef> &typeDef);
+                  uint64_t maxSize);
 
     void addLiteralDefine(std::string name, std::string literal,
                           std::shared_ptr<Type> type);

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -22,7 +22,8 @@ class IR {
     void addFunction(std::string name, std::vector<Parameter *> parameters,
                      std::shared_ptr<Type> retType, bool isVariadic);
 
-    void addTypeDef(std::string name, std::shared_ptr<Type> type);
+    std::shared_ptr<TypeDef> addTypeDef(std::string name,
+                                        std::shared_ptr<Type> type);
 
     /**
      * @return type alias for the enum
@@ -37,10 +38,22 @@ class IR {
     addStruct(std::string name, std::vector<Field *> fields, uint64_t typeSize);
 
     /**
+     * Add struct for which TypeDef already exists
+     */
+    void addStruct(std::string name, std::vector<Field *> fields,
+                   uint64_t typeSize, const std::shared_ptr<TypeDef> &typeDef);
+
+    /**
      * @return type alias for the union
      */
     std::shared_ptr<Type>
     addUnion(std::string name, std::vector<Field *> fields, uint64_t maxSize);
+
+    /**
+     * Add union for which TypeDef already exists
+     */
+    void addUnion(std::string name, std::vector<Field *> fields,
+                  uint64_t maxSize, const std::shared_ptr<TypeDef> &typeDef);
 
     void addLiteralDefine(std::string name, std::string literal,
                           std::shared_ptr<Type> type);
@@ -137,8 +150,6 @@ class IR {
     template <typename T>
     T getDeclarationWithName(std::vector<T> &declarations,
                              const std::string &name);
-
-    template <typename T> void clearVector(std::vector<T> v);
 
     std::string libName;    // name of the library
     std::string linkName;   // name of the library to link with

--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -3,7 +3,6 @@
 #include "types/ArrayType.h"
 #include "types/PrimitiveType.h"
 #include <sstream>
-#include <utility>
 
 Field::Field(std::string name, std::shared_ptr<Type> type)
     : TypeAndName(std::move(name), std::move(type)) {}

--- a/bindgen/ir/TypeAndName.cpp
+++ b/bindgen/ir/TypeAndName.cpp
@@ -2,7 +2,7 @@
 #include <clang/Tooling/Tooling.h>
 
 TypeAndName::TypeAndName(std::string name, std::shared_ptr<Type> type)
-    : name(std::move(name)), type(type) {}
+    : name(std::move(name)), type(std::move(type)) {}
 
 std::shared_ptr<Type> TypeAndName::getType() const { return type; }
 

--- a/bindgen/ir/TypeDef.cpp
+++ b/bindgen/ir/TypeDef.cpp
@@ -2,9 +2,15 @@
 #include "../Utils.h"
 
 TypeDef::TypeDef(std::string name, std::shared_ptr<Type> type)
-    : TypeAndName(std::move(name), type) {}
+    : TypeAndName(std::move(name), std::move(type)) {}
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const TypeDef &typeDef) {
+    if (!typeDef.getType()) {
+        llvm::errs() << "Error: type declaration for " << typeDef.getName()
+                     << " was not found.\n";
+        llvm::errs().flush();
+        return s;
+    }
     s << "  type " + handleReservedWords(typeDef.name) + " = " +
              typeDef.getType()->str() + "\n";
     return s;

--- a/bindgen/ir/types/ArrayType.cpp
+++ b/bindgen/ir/types/ArrayType.cpp
@@ -2,7 +2,7 @@
 #include "../../Utils.h"
 
 ArrayType::ArrayType(std::shared_ptr<Type> elementsType, uint64_t size)
-    : size(size), elementsType(elementsType) {}
+    : size(size), elementsType(std::move(elementsType)) {}
 
 std::string ArrayType::str() const {
     return "native.CArray[" + elementsType->str() + ", " +
@@ -12,5 +12,3 @@ std::string ArrayType::str() const {
 bool ArrayType::usesType(std::shared_ptr<Type> type) const {
     return this == type.get() || elementsType == type;
 }
-
-ArrayType::~ArrayType() {}

--- a/bindgen/ir/types/ArrayType.h
+++ b/bindgen/ir/types/ArrayType.h
@@ -7,7 +7,7 @@ class ArrayType : public Type {
   public:
     ArrayType(std::shared_ptr<Type> elementsType, uint64_t size);
 
-    ~ArrayType() override;
+    ~ArrayType() override = default;
 
     bool usesType(std::shared_ptr<Type> type) const override;
 

--- a/bindgen/ir/types/FunctionPointerType.cpp
+++ b/bindgen/ir/types/FunctionPointerType.cpp
@@ -4,7 +4,7 @@
 FunctionPointerType::FunctionPointerType(
     std::shared_ptr<Type> returnType,
     const std::vector<std::shared_ptr<Type>> &parametersTypes, bool isVariadic)
-    : returnType(returnType), parametersTypes(parametersTypes),
+    : returnType(std::move(returnType)), parametersTypes(parametersTypes),
       isVariadic(isVariadic) {}
 
 std::string FunctionPointerType::str() const {
@@ -30,12 +30,10 @@ bool FunctionPointerType::usesType(std::shared_ptr<Type> type) const {
         return true;
     }
 
-    for (auto parameterType : parametersTypes) {
+    for (const auto &parameterType : parametersTypes) {
         if (parameterType == type) {
             return true;
         }
     }
     return false;
 }
-
-FunctionPointerType::~FunctionPointerType() {}

--- a/bindgen/ir/types/FunctionPointerType.h
+++ b/bindgen/ir/types/FunctionPointerType.h
@@ -11,7 +11,7 @@ class FunctionPointerType : public Type {
         const std::vector<std::shared_ptr<Type>> &parametersTypes,
         bool isVariadic);
 
-    ~FunctionPointerType() override;
+    ~FunctionPointerType() override = default;
 
     bool usesType(std::shared_ptr<Type> type) const override;
 

--- a/bindgen/ir/types/PointerType.cpp
+++ b/bindgen/ir/types/PointerType.cpp
@@ -1,6 +1,6 @@
 #include "PointerType.h"
 
-PointerType::PointerType(std::shared_ptr<Type> type) : type(type) {}
+PointerType::PointerType(std::shared_ptr<Type> type) : type(std::move(type)) {}
 
 std::string PointerType::str() const {
     return "native.Ptr[" + type->str() + "]";
@@ -12,5 +12,3 @@ bool PointerType::usesType(std::shared_ptr<Type> type) const {
     }
     return this->type == type;
 }
-
-PointerType::~PointerType() {}

--- a/bindgen/ir/types/PointerType.h
+++ b/bindgen/ir/types/PointerType.h
@@ -7,7 +7,7 @@ class PointerType : public Type {
   public:
     explicit PointerType(std::shared_ptr<Type> type);
 
-    ~PointerType() override;
+    ~PointerType() override = default;
 
     bool usesType(std::shared_ptr<Type> type) const override;
 

--- a/bindgen/ir/types/Type.cpp
+++ b/bindgen/ir/types/Type.cpp
@@ -3,5 +3,3 @@
 std::string Type::str() const { return ""; }
 
 bool Type::usesType(std::shared_ptr<Type> type) const { return false; }
-
-Type::~Type() = default;

--- a/bindgen/ir/types/Type.h
+++ b/bindgen/ir/types/Type.h
@@ -9,7 +9,7 @@
  */
 class Type {
   public:
-    virtual ~Type();
+    virtual ~Type() = default;
 
     virtual std::string str() const;
 

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -114,16 +114,7 @@ void TreeVisitor::handleUnion(clang::RecordDecl *record, std::string name) {
         fields.push_back(new Field(fname, ftype));
     }
 
-    std::shared_ptr<Type> alias = nullptr;
-
-    std::shared_ptr<TypeDef> typeDef = ir.getTypeDefWithName("union_" + name);
-    if (typeDef) {
-        /* typedef for this union already exists */
-        ir.addUnion(name, std::move(fields), maxSize, typeDef);
-        alias = typeDef;
-    } else {
-        alias = ir.addUnion(name, std::move(fields), maxSize);
-    }
+    ir.addUnion(name, std::move(fields), maxSize);
 }
 
 void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
@@ -161,16 +152,8 @@ void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
 
     uint64_t sizeInBits = astContext->getTypeSize(record->getTypeForDecl());
     assert(sizeInBits % 8 == 0);
-    std::shared_ptr<Type> alias = nullptr;
 
-    std::shared_ptr<TypeDef> typeDef = ir.getTypeDefWithName(newName);
-    if (typeDef) {
-        /* typedef for this struct already exists */
-        alias = typeDef;
-        ir.addStruct(name, std::move(fields), sizeInBits / 8, typeDef);
-    } else {
-        alias = ir.addStruct(name, std::move(fields), sizeInBits / 8);
-    }
+    ir.addStruct(name, std::move(fields), sizeInBits / 8);
 }
 
 bool TreeVisitor::VisitVarDecl(clang::VarDecl *varDecl) {

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -71,9 +71,6 @@ bool TreeVisitor::VisitEnumDecl(clang::EnumDecl *enumdecl) {
 
     std::shared_ptr<Type> alias =
         ir.addEnum(name, scalaType, std::move(enumerators));
-    if (alias != nullptr) {
-        typeTranslator.addAlias("enum " + name, alias);
-    }
 
     return true;
 }
@@ -127,8 +124,6 @@ void TreeVisitor::handleUnion(clang::RecordDecl *record, std::string name) {
     } else {
         alias = ir.addUnion(name, std::move(fields), maxSize);
     }
-
-    typeTranslator.addAlias("union " + name, alias);
 }
 
 void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
@@ -176,8 +171,6 @@ void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
     } else {
         alias = ir.addStruct(name, std::move(fields), sizeInBits / 8);
     }
-
-    typeTranslator.addAlias("struct " + name, alias);
 }
 
 bool TreeVisitor::VisitVarDecl(clang::VarDecl *varDecl) {

--- a/tests/samples/OpaqueTypes.h
+++ b/tests/samples/OpaqueTypes.h
@@ -1,0 +1,22 @@
+struct point;
+struct point *move(struct point *point, int x, int y);
+
+typedef struct points points;
+typedef union u u;
+
+union u *processPoints(points *p);
+
+union u {
+    int i;
+    float f;
+};
+
+struct points {
+    struct point *point1;
+    struct point *point2;
+};
+
+struct point {
+    int x;
+    int y;
+};

--- a/tests/samples/OpaqueTypes.h
+++ b/tests/samples/OpaqueTypes.h
@@ -1,7 +1,8 @@
+typedef struct points points;
+
 struct point;
 struct point *move(struct point *point, int x, int y);
 
-typedef struct points points;
 typedef union u u;
 
 union u *processPoints(points *p);

--- a/tests/samples/OpaqueTypes.scala
+++ b/tests/samples/OpaqueTypes.scala
@@ -6,9 +6,9 @@ import scala.scalanative.native._
 @native.link("bindgentests")
 @native.extern
 object OpaqueTypes {
-  type struct_point = native.CStruct2[native.CInt, native.CInt]
   type struct_points = native.CStruct2[native.Ptr[struct_point], native.Ptr[struct_point]]
   type points = struct_points
+  type struct_point = native.CStruct2[native.CInt, native.CInt]
   type union_u = native.CArray[Byte, native.Nat._4]
   type u = union_u
   def move(point: native.Ptr[struct_point], x: native.CInt, y: native.CInt): native.Ptr[struct_point] = native.extern

--- a/tests/samples/OpaqueTypes.scala
+++ b/tests/samples/OpaqueTypes.scala
@@ -1,0 +1,46 @@
+package org.scalanative.bindgen.samples
+
+import scala.scalanative._
+import scala.scalanative.native._
+
+@native.link("bindgentests")
+@native.extern
+object OpaqueTypes {
+  type struct_point = native.CStruct2[native.CInt, native.CInt]
+  type struct_points = native.CStruct2[native.Ptr[struct_point], native.Ptr[struct_point]]
+  type points = struct_points
+  type union_u = native.CArray[Byte, native.Nat._4]
+  type u = union_u
+  def move(point: native.Ptr[struct_point], x: native.CInt, y: native.CInt): native.Ptr[struct_point] = native.extern
+  def processPoints(p: native.Ptr[points]): native.Ptr[union_u] = native.extern
+}
+
+import OpaqueTypes._
+
+object OpaqueTypesHelpers {
+
+  implicit class struct_points_ops(val p: native.Ptr[struct_points]) extends AnyVal {
+    def point1: native.Ptr[struct_point] = !p._1
+    def point1_=(value: native.Ptr[struct_point]): Unit = !p._1 = value
+    def point2: native.Ptr[struct_point] = !p._2
+    def point2_=(value: native.Ptr[struct_point]): Unit = !p._2 = value
+  }
+
+  def struct_points()(implicit z: native.Zone): native.Ptr[struct_points] = native.alloc[struct_points]
+
+  implicit class struct_point_ops(val p: native.Ptr[struct_point]) extends AnyVal {
+    def x: native.CInt = !p._1
+    def x_=(value: native.CInt): Unit = !p._1 = value
+    def y: native.CInt = !p._2
+    def y_=(value: native.CInt): Unit = !p._2 = value
+  }
+
+  def struct_point()(implicit z: native.Zone): native.Ptr[struct_point] = native.alloc[struct_point]
+
+  implicit class union_u_pos(val p: native.Ptr[union_u]) extends AnyVal {
+    def i: native.Ptr[native.CInt] = p.cast[native.Ptr[native.CInt]]
+    def i_=(value: native.CInt): Unit = !p.cast[native.Ptr[native.CInt]] = value
+    def f: native.Ptr[native.CFloat] = p.cast[native.Ptr[native.CFloat]]
+    def f_=(value: native.CFloat): Unit = !p.cast[native.Ptr[native.CFloat]] = value
+  }
+}


### PR DESCRIPTION
Closes #78 
Closes #88

Create `TypeDef` instance that references `OpaqueType`
Replace `OpaqueType` instances by `Struct` or `Union` when types are declared