### PR TITLE
Check if type is alias for struct/union before generating setter/getter

### DIFF
--- a/bindgen/Utils.h
+++ b/bindgen/Utils.h
@@ -3,6 +3,7 @@
 
 #include <clang/AST/AST.h>
 
+#include "ir/TypeDef.h"
 #include "ir/types/Type.h"
 #include <algorithm>
 #include <cctype>
@@ -98,6 +99,18 @@ static inline bool startsWith(const std::string &str,
 template <typename T, typename PT> static inline bool isInstanceOf(PT *type) {
     auto *p = dynamic_cast<T *>(type);
     return p != nullptr;
+}
+
+/**
+ * Types may be wrapper in a chain of typedefs.
+ * @return true if given type is of type T or is an alias for type T.
+ */
+template <typename T> static inline bool isAliasForType(Type *type) {
+    if (isInstanceOf<TypeDef>(type)) {
+        auto *typeDef = dynamic_cast<TypeDef *>(type);
+        return isAliasForType<T>(typeDef->getType().get());
+    }
+    return isInstanceOf<T>(type);
 }
 
 #endif // UTILS_H

--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -12,8 +12,8 @@ std::string Field::generateSetter(int fieldIndex) {
     std::string setter = handleReservedWords(getName(), "_=");
     std::string parameterType = type->str();
     std::string value = "value";
-    if (isInstanceOf<ArrayType>(type.get()) ||
-        isInstanceOf<Struct>(type.get())) {
+    if (isAliasForType<ArrayType>(type.get()) ||
+        isAliasForType<Struct>(type.get())) {
         parameterType = "native.Ptr[" + parameterType + "]";
         value = "!" + value;
     }
@@ -27,8 +27,8 @@ std::string Field::generateGetter(int fieldIndex) {
     std::string getter = handleReservedWords(getName());
     std::string returnType = type->str();
     std::string methodBody;
-    if (isInstanceOf<ArrayType>(type.get()) ||
-        isInstanceOf<Struct>(type.get())) {
+    if (isAliasForType<ArrayType>(type.get()) ||
+        isAliasForType<Struct>(type.get())) {
         returnType = "native.Ptr[" + returnType + "]";
         methodBody = "p._" + std::to_string(fieldIndex + 1);
     } else {

--- a/tests/samples/ReservedWords.scala
+++ b/tests/samples/ReservedWords.scala
@@ -37,8 +37,8 @@ object ReservedWordsHelpers {
   implicit class struct_finally_ops(val p: native.Ptr[struct_finally]) extends AnyVal {
     def `val`: `def` = !p._1
     def `val_=`(value: `def`): Unit = !p._1 = value
-    def `finally`: `lazy` = !p._2
-    def `finally_=`(value: `lazy`): Unit = !p._2 = value
+    def `finally`: native.Ptr[`lazy`] = p._2
+    def `finally_=`(value: native.Ptr[`lazy`]): Unit = !p._2 = !value
   }
 
   def struct_finally()(implicit z: native.Zone): native.Ptr[struct_finally] = native.alloc[struct_finally]

--- a/tests/samples/Struct.c
+++ b/tests/samples/Struct.c
@@ -1,7 +1,27 @@
 #include "Struct.h"
 #include <stdlib.h>
 
-point_s getPoint() {
+void setPoints(struct points *points, int x1, int y1, int x2, int y2) {
+    points->p1.x = x1;
+    points->p1.y = y1;
+    points->p2.x = x2;
+    points->p2.y = y2;
+}
+
+int getPoint(struct points *points, enum pointIndex pointIndex) {
+    switch (pointIndex) {
+    case X1:
+        return points->p1.x;
+    case X2:
+        return points->p2.x;
+    case Y1:
+        return points->p1.y;
+    case Y2:
+        return points->p2.y;
+    }
+}
+
+point_s createPoint() {
     point_s point = malloc(sizeof(struct point));
     point->x = 10;
     point->y = 20;

--- a/tests/samples/Struct.h
+++ b/tests/samples/Struct.h
@@ -3,9 +3,22 @@ struct point {
     int y;
 };
 
+typedef struct point point;
+
+struct points {
+    struct point p1;
+    point p2;
+};
+
+enum pointIndex { X1, Y1, X2, Y2 };
+
+void setPoints(struct points *points, int x1, int y1, int x2, int y2);
+
+int getPoint(struct points *points, enum pointIndex pointIndex);
+
 typedef struct point *point_s;
 
-point_s getPoint();
+point_s createPoint();
 
 struct bigStruct {
     long one;

--- a/tests/samples/Struct.scala
+++ b/tests/samples/Struct.scala
@@ -7,16 +7,28 @@ import scala.scalanative.native._
 @native.extern
 object Struct {
   type struct_point = native.CStruct2[native.CInt, native.CInt]
+  type point = struct_point
+  type struct_points = native.CStruct2[struct_point, point]
+  type enum_pointIndex = native.CUnsignedInt
   type point_s = native.Ptr[struct_point]
   type struct_bigStruct = native.CArray[Byte, native.Nat.Digit[native.Nat._1, native.Nat.Digit[native.Nat._1, native.Nat._2]]]
   type struct_structWithAnonymousStruct = native.CStruct2[native.CInt, native.CArray[Byte, native.Nat._8]]
-  def getPoint(): native.Ptr[struct_point] = native.extern
+  def setPoints(points: native.Ptr[struct_points], x1: native.CInt, y1: native.CInt, x2: native.CInt, y2: native.CInt): Unit = native.extern
+  def getPoint(points: native.Ptr[struct_points], pointIndex: enum_pointIndex): native.CInt = native.extern
+  def createPoint(): native.Ptr[struct_point] = native.extern
   def getBigStructSize(): native.CInt = native.extern
   def getCharFromAnonymousStruct(s: native.Ptr[struct_structWithAnonymousStruct]): native.CChar = native.extern
   def getIntFromAnonymousStruct(s: native.Ptr[struct_structWithAnonymousStruct]): native.CChar = native.extern
 }
 
 import Struct._
+
+object StructEnums {
+  final val enum_pointIndex_X1: enum_pointIndex = 0.toUInt
+  final val enum_pointIndex_Y1: enum_pointIndex = 1.toUInt
+  final val enum_pointIndex_X2: enum_pointIndex = 2.toUInt
+  final val enum_pointIndex_Y2: enum_pointIndex = 3.toUInt
+}
 
 object StructHelpers {
 
@@ -28,6 +40,15 @@ object StructHelpers {
   }
 
   def struct_point()(implicit z: native.Zone): native.Ptr[struct_point] = native.alloc[struct_point]
+
+  implicit class struct_points_ops(val p: native.Ptr[struct_points]) extends AnyVal {
+    def p1: native.Ptr[struct_point] = p._1
+    def p1_=(value: native.Ptr[struct_point]): Unit = !p._1 = !value
+    def p2: native.Ptr[point] = p._2
+    def p2_=(value: native.Ptr[point]): Unit = !p._2 = !value
+  }
+
+  def struct_points()(implicit z: native.Zone): native.Ptr[struct_points] = native.alloc[struct_points]
 
   implicit class struct_structWithAnonymousStruct_ops(val p: native.Ptr[struct_structWithAnonymousStruct]) extends AnyVal {
     def a: native.CInt = !p._1

--- a/tests/samples/src/test/scala/org/scalanative/bindgen/samples/StructTests.scala
+++ b/tests/samples/src/test/scala/org/scalanative/bindgen/samples/StructTests.scala
@@ -3,20 +3,46 @@ package org.scalanative.bindgen.samples
 import utest._
 import scala.scalanative.native._
 import org.scalanative.bindgen.samples.StructHelpers._
+import org.scalanative.bindgen.samples.StructEnums._
 
 object StructTests extends TestSuite {
   val tests = Tests {
-    'getPoint - {
-      val point = Struct.getPoint()
+    'point - {
+      val point = Struct.createPoint()
       assert(point.x == 10)
       assert(point.y == 20)
 
-      point.x_=(11)
+      point.x = 11
       assert(point.x == 11)
     }
 
     'bigStructSize - {
       assert(Struct.getBigStructSize() == sizeof[Struct.struct_bigStruct])
+    }
+
+    'getFieldsOfInnerStruct - {
+      Zone { implicit zone =>
+        val points = struct_points()
+        Struct.setPoints(points, 1, 2, 3, 4)
+        assert(1 == points.p1.x)
+        assert(2 == points.p1.y)
+        assert(3 == points.p2.x)
+        assert(4 == points.p2.y)
+      }
+    }
+
+    'setFieldsOfInnerStruct - {
+      Zone { implicit zone =>
+        val points = struct_points()
+        points.p1.x = 1
+        points.p1.y = 2
+        points.p2.x = 3
+        points.p2.y = 4
+        assert(1 == Struct.getPoint(points, enum_pointIndex_X1))
+        assert(2 == Struct.getPoint(points, enum_pointIndex_Y1))
+        assert(3 == Struct.getPoint(points, enum_pointIndex_X2))
+        assert(4 == Struct.getPoint(points, enum_pointIndex_Y2))
+      }
     }
 
     'innerAnonymousStruct - {
@@ -28,7 +54,7 @@ object StructTests extends TestSuite {
 
         val structWithAnonymousStruct = struct_structWithAnonymousStruct()
         val array = anonymousStruct.cast[Ptr[CArray[Byte, Nat._8]]]
-        structWithAnonymousStruct.anonymousStruct_=(array)
+        structWithAnonymousStruct.anonymousStruct = array
 
         assert('a' == Struct.getCharFromAnonymousStruct(structWithAnonymousStruct))
         assert(42 == Struct.getIntFromAnonymousStruct(structWithAnonymousStruct))


### PR DESCRIPTION
#93 fixed helper methods for fields of type `CStruct` and `CArray` but it did not check if type is an alias for one of these types.