### PR TITLE
Proper implementation of usesType method

### DIFF
--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -62,7 +62,7 @@ bool StructOrUnion::operator==(const StructOrUnion &other) const {
             return false;
         }
         for (size_t i = 0; i < fields.size(); i++) {
-            if (!(*fields[i] == *s->fields[i])) {
+            if (*fields[i] != *s->fields[i]) {
                 return false;
             }
         }

--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -49,6 +49,28 @@ StructOrUnion::~StructOrUnion() {
     }
 }
 
+bool StructOrUnion::operator==(const StructOrUnion &other) const {
+    if (this == &other) {
+        return true;
+    }
+    if (isInstanceOf<const Struct>(&other)) {
+        auto *s = dynamic_cast<const Struct *>(&other);
+        if (name != s->name) {
+            return false;
+        }
+        if (fields.size() != s->fields.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < fields.size(); i++) {
+            if (!(*fields[i] == *s->fields[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
 Struct::Struct(std::string name, std::vector<Field *> fields, uint64_t typeSize)
     : StructOrUnion(std::move(name), std::move(fields)), typeSize(typeSize) {}
 
@@ -112,12 +134,9 @@ std::string Struct::str() const {
     return ss.str();
 }
 
-bool Struct::usesType(std::shared_ptr<Type> type) const {
-    if (this == type.get()) {
-        return true;
-    }
+bool Struct::usesType(const std::shared_ptr<Type> &type) const {
     for (const auto &field : fields) {
-        if (field->getType() == type) {
+        if (*field->getType() == *type) {
             return true;
         }
     }

--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -30,6 +30,8 @@ class StructOrUnion {
 
     std::string getName() const;
 
+    bool operator==(const StructOrUnion &other) const;
+
   protected:
     std::string name;
     std::vector<Field *> fields;
@@ -52,9 +54,11 @@ class Struct : public StructOrUnion,
      */
     bool hasHelperMethods() const;
 
-    bool usesType(std::shared_ptr<Type> type) const override;
+    bool usesType(const std::shared_ptr<Type> &type) const override;
 
     std::string str() const override;
+
+    using StructOrUnion::operator==;
 
   private:
     /* type size is needed if number of fields is bigger than 22 */
@@ -70,6 +74,8 @@ class Union : public StructOrUnion,
     std::shared_ptr<TypeDef> generateTypeDef() override;
 
     std::string generateHelperClass() const override;
+
+    using StructOrUnion::operator==;
 
   private:
     std::string getTypeAlias() const;

--- a/bindgen/ir/TypeAndName.cpp
+++ b/bindgen/ir/TypeAndName.cpp
@@ -9,3 +9,7 @@ std::shared_ptr<Type> TypeAndName::getType() const { return type; }
 std::string TypeAndName::getName() const { return name; }
 
 void TypeAndName::setType(std::shared_ptr<Type> type) { this->type = type; }
+
+bool TypeAndName::operator==(const TypeAndName &other) const {
+    return name == other.name && *type == *other.type;
+}

--- a/bindgen/ir/TypeAndName.cpp
+++ b/bindgen/ir/TypeAndName.cpp
@@ -13,3 +13,7 @@ void TypeAndName::setType(std::shared_ptr<Type> type) { this->type = type; }
 bool TypeAndName::operator==(const TypeAndName &other) const {
     return name == other.name && *type == *other.type;
 }
+
+bool TypeAndName::operator!=(const TypeAndName &other) const {
+    return !(*this == other);
+}

--- a/bindgen/ir/TypeAndName.h
+++ b/bindgen/ir/TypeAndName.h
@@ -21,6 +21,8 @@ class TypeAndName {
 
     bool operator==(const TypeAndName &other) const;
 
+    bool operator!=(const TypeAndName &other) const;
+
   protected:
     std::string name;
     std::shared_ptr<Type> type;

--- a/bindgen/ir/TypeAndName.h
+++ b/bindgen/ir/TypeAndName.h
@@ -19,6 +19,8 @@ class TypeAndName {
 
     std::string getName() const;
 
+    bool operator==(const TypeAndName &other) const;
+
   protected:
     std::string name;
     std::shared_ptr<Type> type;

--- a/bindgen/ir/TypeDef.cpp
+++ b/bindgen/ir/TypeDef.cpp
@@ -1,5 +1,7 @@
 #include "TypeDef.h"
 #include "../Utils.h"
+#include "Enum.h"
+#include "Struct.h"
 
 TypeDef::TypeDef(std::string name, std::shared_ptr<Type> type)
     : TypeAndName(std::move(name), std::move(type)) {}
@@ -16,8 +18,22 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const TypeDef &typeDef) {
     return s;
 }
 
-bool TypeDef::usesType(std::shared_ptr<Type> type) const {
-    return this == type.get() || this->type == type;
+bool TypeDef::usesType(const std::shared_ptr<Type> &type) const {
+    return *this->type == *type;
 }
 
 std::string TypeDef::str() const { return handleReservedWords(name); }
+
+bool TypeDef::operator==(const Type &other) const {
+    if (this == &other) {
+        return true;
+    }
+    if (isInstanceOf<const TypeDef>(&other)) {
+        auto *typDef = dynamic_cast<const TypeDef *>(&other);
+        if (name != typDef->name) {
+            return false;
+        }
+        return *type == *typDef->type;
+    }
+    return false;
+}

--- a/bindgen/ir/TypeDef.h
+++ b/bindgen/ir/TypeDef.h
@@ -12,9 +12,11 @@ class TypeDef : public TypeAndName, public Type {
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const TypeDef &type);
 
-    bool usesType(std::shared_ptr<Type> type) const override;
+    bool usesType(const std::shared_ptr<Type> &type) const override;
 
     std::string str() const override;
+
+    bool operator==(const Type &other) const override;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_TYPEDEF_H

--- a/bindgen/ir/types/ArrayType.cpp
+++ b/bindgen/ir/types/ArrayType.cpp
@@ -9,6 +9,20 @@ std::string ArrayType::str() const {
            uint64ToScalaNat(size) + "]";
 }
 
-bool ArrayType::usesType(std::shared_ptr<Type> type) const {
-    return this == type.get() || elementsType == type;
+bool ArrayType::usesType(const std::shared_ptr<Type> &type) const {
+    return *elementsType == *type;
+}
+
+bool ArrayType::operator==(const Type &other) const {
+    if (this == &other) {
+        return true;
+    }
+    if (isInstanceOf<const ArrayType>(&other)) {
+        auto *arrayType = dynamic_cast<const ArrayType *>(&other);
+        if (size != arrayType->size) {
+            return false;
+        }
+        return *elementsType == *arrayType->elementsType.get();
+    }
+    return false;
 }

--- a/bindgen/ir/types/ArrayType.h
+++ b/bindgen/ir/types/ArrayType.h
@@ -2,6 +2,7 @@
 #define SCALA_NATIVE_BINDGEN_ARRAYTYPE_H
 
 #include "Type.h"
+#include <stdint-gcc.h>
 
 class ArrayType : public Type {
   public:
@@ -9,9 +10,11 @@ class ArrayType : public Type {
 
     ~ArrayType() override = default;
 
-    bool usesType(std::shared_ptr<Type> type) const override;
+    bool usesType(const std::shared_ptr<Type> &type) const override;
 
     std::string str() const override;
+
+    bool operator==(const Type &other) const override;
 
   private:
     const uint64_t size;

--- a/bindgen/ir/types/FunctionPointerType.cpp
+++ b/bindgen/ir/types/FunctionPointerType.cpp
@@ -46,7 +46,7 @@ bool FunctionPointerType::operator==(const Type &other) const {
         if (isVariadic != functionPointerType->isVariadic) {
             return false;
         }
-        if (!(*returnType == *functionPointerType->returnType)) {
+        if (*returnType != *functionPointerType->returnType) {
             return false;
         }
         if (parametersTypes.size() !=
@@ -54,8 +54,8 @@ bool FunctionPointerType::operator==(const Type &other) const {
             return false;
         }
         for (size_t i = 0; i < parametersTypes.size(); i++) {
-            if (!(*parametersTypes[i] ==
-                  *functionPointerType->parametersTypes[i])) {
+            if (*parametersTypes[i] !=
+                *functionPointerType->parametersTypes[i]) {
                 return false;
             }
         }

--- a/bindgen/ir/types/FunctionPointerType.cpp
+++ b/bindgen/ir/types/FunctionPointerType.cpp
@@ -1,4 +1,5 @@
 #include "FunctionPointerType.h"
+#include "../../Utils.h"
 #include <sstream>
 
 FunctionPointerType::FunctionPointerType(
@@ -22,18 +23,43 @@ std::string FunctionPointerType::str() const {
     return ss.str();
 }
 
-bool FunctionPointerType::usesType(std::shared_ptr<Type> type) const {
-    if (this == type.get()) {
-        return true;
-    }
-    if (returnType == type) {
+bool FunctionPointerType::usesType(const std::shared_ptr<Type> &type) const {
+    if (*returnType == *type) {
         return true;
     }
 
     for (const auto &parameterType : parametersTypes) {
-        if (parameterType == type) {
+        if (*parameterType == *type) {
             return true;
         }
+    }
+    return false;
+}
+
+bool FunctionPointerType::operator==(const Type &other) const {
+    if (this == &other) {
+        return true;
+    }
+    if (isInstanceOf<const FunctionPointerType>(&other)) {
+        auto *functionPointerType =
+            dynamic_cast<const FunctionPointerType *>(&other);
+        if (isVariadic != functionPointerType->isVariadic) {
+            return false;
+        }
+        if (!(*returnType == *functionPointerType->returnType)) {
+            return false;
+        }
+        if (parametersTypes.size() !=
+            functionPointerType->parametersTypes.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < parametersTypes.size(); i++) {
+            if (!(*parametersTypes[i] ==
+                  *functionPointerType->parametersTypes[i])) {
+                return false;
+            }
+        }
+        return true;
     }
     return false;
 }

--- a/bindgen/ir/types/FunctionPointerType.h
+++ b/bindgen/ir/types/FunctionPointerType.h
@@ -13,9 +13,11 @@ class FunctionPointerType : public Type {
 
     ~FunctionPointerType() override = default;
 
-    bool usesType(std::shared_ptr<Type> type) const override;
+    bool usesType(const std::shared_ptr<Type> &type) const override;
 
     std::string str() const override;
+
+    bool operator==(const Type &other) const override;
 
   private:
     std::shared_ptr<Type> returnType;

--- a/bindgen/ir/types/PointerType.cpp
+++ b/bindgen/ir/types/PointerType.cpp
@@ -1,4 +1,5 @@
 #include "PointerType.h"
+#include "../../Utils.h"
 
 PointerType::PointerType(std::shared_ptr<Type> type) : type(std::move(type)) {}
 
@@ -6,9 +7,17 @@ std::string PointerType::str() const {
     return "native.Ptr[" + type->str() + "]";
 }
 
-bool PointerType::usesType(std::shared_ptr<Type> type) const {
-    if (this == type.get()) {
+bool PointerType::usesType(const std::shared_ptr<Type> &type) const {
+    return *this->type == *type;
+}
+
+bool PointerType::operator==(const Type &other) const {
+    if (this == &other) {
         return true;
     }
-    return this->type == type;
+    if (isInstanceOf<const PointerType>(&other)) {
+        auto *pointerType = dynamic_cast<const PointerType *>(&other);
+        return *type == *pointerType->type;
+    }
+    return false;
 }

--- a/bindgen/ir/types/PointerType.h
+++ b/bindgen/ir/types/PointerType.h
@@ -9,9 +9,11 @@ class PointerType : public Type {
 
     ~PointerType() override = default;
 
-    bool usesType(std::shared_ptr<Type> type) const override;
+    bool usesType(const std::shared_ptr<Type> &type) const override;
 
     std::string str() const override;
+
+    bool operator==(const Type &other) const override;
 
   private:
     std::shared_ptr<Type> type;

--- a/bindgen/ir/types/PrimitiveType.cpp
+++ b/bindgen/ir/types/PrimitiveType.cpp
@@ -7,9 +7,17 @@ std::string PrimitiveType::str() const { return handleReservedWords(type); }
 
 std::string PrimitiveType::getType() const { return type; }
 
-bool PrimitiveType::usesType(std::shared_ptr<Type> type) const {
-    if (this == type.get()) {
+bool PrimitiveType::usesType(const std::shared_ptr<Type> &type) const {
+    return false;
+}
+
+bool PrimitiveType::operator==(const Type &other) const {
+    if (this == &other) {
         return true;
     }
-    return str() == type->str();
+    if (isInstanceOf<const PrimitiveType>(&other)) {
+        auto *primitiveType = dynamic_cast<const PrimitiveType *>(&other);
+        return type == primitiveType->type;
+    }
+    return false;
 }

--- a/bindgen/ir/types/PrimitiveType.h
+++ b/bindgen/ir/types/PrimitiveType.h
@@ -13,9 +13,11 @@ class PrimitiveType : public Type {
 
     std::string getType() const;
 
-    bool usesType(std::shared_ptr<Type> type) const override;
+    bool usesType(const std::shared_ptr<Type> &type) const override;
 
     std::string str() const override;
+
+    bool operator==(const Type &other) const override;
 
   private:
     std::string type;

--- a/bindgen/ir/types/Type.cpp
+++ b/bindgen/ir/types/Type.cpp
@@ -5,3 +5,5 @@ std::string Type::str() const { return ""; }
 bool Type::usesType(const std::shared_ptr<Type> &type) const { return false; }
 
 bool Type::operator==(const Type &other) const { return false; }
+
+bool Type::operator!=(const Type &other) const { return !(*this == other); }

--- a/bindgen/ir/types/Type.cpp
+++ b/bindgen/ir/types/Type.cpp
@@ -2,4 +2,6 @@
 
 std::string Type::str() const { return ""; }
 
-bool Type::usesType(std::shared_ptr<Type> type) const { return false; }
+bool Type::usesType(const std::shared_ptr<Type> &type) const { return false; }
+
+bool Type::operator==(const Type &other) const { return false; }

--- a/bindgen/ir/types/Type.h
+++ b/bindgen/ir/types/Type.h
@@ -13,7 +13,9 @@ class Type {
 
     virtual std::string str() const;
 
-    virtual bool usesType(std::shared_ptr<Type> type) const;
+    virtual bool usesType(const std::shared_ptr<Type> &type) const;
+
+    virtual bool operator==(const Type &other) const;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_TYPE_H

--- a/bindgen/ir/types/Type.h
+++ b/bindgen/ir/types/Type.h
@@ -16,6 +16,8 @@ class Type {
     virtual bool usesType(const std::shared_ptr<Type> &type) const;
 
     virtual bool operator==(const Type &other) const;
+
+    virtual bool operator!=(const Type &other) const;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_TYPE_H


### PR DESCRIPTION
It used to compare pointers, I added `operator==` method to subclasses of `Type`