### PR TITLE
Do not search usages of typedef in other typedefs

### DIFF
--- a/bindgen/ir/Function.cpp
+++ b/bindgen/ir/Function.cpp
@@ -29,12 +29,13 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Function &func) {
     return s;
 }
 
-bool Function::usesType(std::shared_ptr<Type> type) const {
-    if (retType == type) {
+bool Function::usesType(std::shared_ptr<Type> type, bool stopOnTypeDefs) const {
+    if (*retType == *type || retType.get()->usesType(type, stopOnTypeDefs)) {
         return true;
     }
     for (const auto &parameter : parameters) {
-        if (parameter->getType() == type) {
+        if (*parameter->getType() == *type ||
+            parameter->getType().get()->usesType(type, stopOnTypeDefs)) {
             return true;
         }
     }

--- a/bindgen/ir/Function.h
+++ b/bindgen/ir/Function.h
@@ -21,7 +21,7 @@ class Function {
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const Function &func);
 
-    bool usesType(std::shared_ptr<Type> type) const;
+    bool usesType(std::shared_ptr<Type> type, bool stopOnTypeDefs) const;
 
     std::string getName() const;
 

--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -230,9 +230,9 @@ void IR::replaceTypeInTypeDefs(std::shared_ptr<Type> oldType,
 
 template <typename T>
 bool IR::isTypeUsed(const std::vector<T> &declarations,
-                    std::shared_ptr<Type> type) {
-    for (const auto decl : declarations) {
-        if (decl->usesType(type)) {
+                    std::shared_ptr<Type> type, bool stopOnTypeDefs) {
+    for (const auto &decl : declarations) {
+        if (decl->usesType(type, stopOnTypeDefs)) {
             return true;
         }
     }
@@ -240,8 +240,12 @@ bool IR::isTypeUsed(const std::vector<T> &declarations,
 }
 
 bool IR::typeIsUsedOnlyInTypeDefs(std::shared_ptr<Type> type) {
-    return !(isTypeUsed(functions, type) || isTypeUsed(structs, type) ||
-             isTypeUsed(unions, type));
+    /* varDefines are not checked here because they are simply
+     * aliases for variables.*/
+    return !(
+        isTypeUsed(functions, type, true) || isTypeUsed(structs, type, true) ||
+        isTypeUsed(unions, type, true) || isTypeUsed(variables, type, true) ||
+        isTypeUsed(literalDefines, type, true));
 }
 
 void IR::setScalaNames() {

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -116,7 +116,7 @@ class IR {
      */
     template <typename T>
     bool isTypeUsed(const std::vector<T> &declarations,
-                    std::shared_ptr<Type> type);
+                    std::shared_ptr<Type> type, bool stopOnTypeDefs);
 
     void setScalaNames();
 

--- a/bindgen/ir/LiteralDefine.cpp
+++ b/bindgen/ir/LiteralDefine.cpp
@@ -10,3 +10,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
       << " = " << literalDefine.literal << "\n";
     return s;
 }
+
+bool LiteralDefine::usesType(const std::shared_ptr<Type> &type,
+                             bool stopOnTypeDefs) const {
+    return *this->type == *type ||
+           this->type.get()->usesType(type, stopOnTypeDefs);
+}

--- a/bindgen/ir/LiteralDefine.h
+++ b/bindgen/ir/LiteralDefine.h
@@ -13,6 +13,8 @@ class LiteralDefine : public Define {
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const LiteralDefine &literalDefine);
 
+    bool usesType(const std::shared_ptr<Type> &type, bool stopOnTypeDefs) const;
+
   private:
     std::string literal;
     std::shared_ptr<Type> type;

--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -134,9 +134,11 @@ std::string Struct::str() const {
     return ss.str();
 }
 
-bool Struct::usesType(const std::shared_ptr<Type> &type) const {
+bool Struct::usesType(const std::shared_ptr<Type> &type,
+                      bool stopOnTypeDefs) const {
     for (const auto &field : fields) {
-        if (*field->getType() == *type) {
+        if (*field->getType() == *type ||
+            field->getType().get()->usesType(type, stopOnTypeDefs)) {
             return true;
         }
     }

--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -54,7 +54,8 @@ class Struct : public StructOrUnion,
      */
     bool hasHelperMethods() const;
 
-    bool usesType(const std::shared_ptr<Type> &type) const override;
+    bool usesType(const std::shared_ptr<Type> &type,
+                  bool stopOnTypeDefs) const override;
 
     std::string str() const override;
 

--- a/bindgen/ir/TypeAndName.cpp
+++ b/bindgen/ir/TypeAndName.cpp
@@ -17,3 +17,9 @@ bool TypeAndName::operator==(const TypeAndName &other) const {
 bool TypeAndName::operator!=(const TypeAndName &other) const {
     return !(*this == other);
 }
+
+bool TypeAndName::usesType(const std::shared_ptr<Type> &type,
+                           bool stopOnTypeDefs) const {
+    return *this->type == *type ||
+           this->type.get()->usesType(type, stopOnTypeDefs);
+}

--- a/bindgen/ir/TypeAndName.h
+++ b/bindgen/ir/TypeAndName.h
@@ -23,6 +23,8 @@ class TypeAndName {
 
     bool operator!=(const TypeAndName &other) const;
 
+    bool usesType(const std::shared_ptr<Type> &type, bool stopOnTypeDefs) const;
+
   protected:
     std::string name;
     std::shared_ptr<Type> type;

--- a/bindgen/ir/TypeDef.cpp
+++ b/bindgen/ir/TypeDef.cpp
@@ -18,8 +18,13 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const TypeDef &typeDef) {
     return s;
 }
 
-bool TypeDef::usesType(const std::shared_ptr<Type> &type) const {
-    return *this->type == *type;
+bool TypeDef::usesType(const std::shared_ptr<Type> &type,
+                       bool stopOnTypeDefs) const {
+    if (stopOnTypeDefs) {
+        return false;
+    }
+    return *this->type == *type ||
+           this->type.get()->usesType(type, stopOnTypeDefs);
 }
 
 std::string TypeDef::str() const { return handleReservedWords(name); }

--- a/bindgen/ir/TypeDef.h
+++ b/bindgen/ir/TypeDef.h
@@ -12,7 +12,8 @@ class TypeDef : public TypeAndName, public Type {
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const TypeDef &type);
 
-    bool usesType(const std::shared_ptr<Type> &type) const override;
+    bool usesType(const std::shared_ptr<Type> &type,
+                  bool stopOnTypeDefs) const override;
 
     std::string str() const override;
 

--- a/bindgen/ir/types/ArrayType.cpp
+++ b/bindgen/ir/types/ArrayType.cpp
@@ -9,8 +9,10 @@ std::string ArrayType::str() const {
            uint64ToScalaNat(size) + "]";
 }
 
-bool ArrayType::usesType(const std::shared_ptr<Type> &type) const {
-    return *elementsType == *type;
+bool ArrayType::usesType(const std::shared_ptr<Type> &type,
+                         bool stopOnTypeDefs) const {
+    return *elementsType == *type ||
+           elementsType.get()->usesType(type, stopOnTypeDefs);
 }
 
 bool ArrayType::operator==(const Type &other) const {

--- a/bindgen/ir/types/ArrayType.h
+++ b/bindgen/ir/types/ArrayType.h
@@ -9,7 +9,8 @@ class ArrayType : public Type {
 
     ~ArrayType() override = default;
 
-    bool usesType(const std::shared_ptr<Type> &type) const override;
+    bool usesType(const std::shared_ptr<Type> &type,
+                  bool stopOnTypeDefs) const override;
 
     std::string str() const override;
 

--- a/bindgen/ir/types/FunctionPointerType.cpp
+++ b/bindgen/ir/types/FunctionPointerType.cpp
@@ -23,13 +23,16 @@ std::string FunctionPointerType::str() const {
     return ss.str();
 }
 
-bool FunctionPointerType::usesType(const std::shared_ptr<Type> &type) const {
-    if (*returnType == *type) {
+bool FunctionPointerType::usesType(const std::shared_ptr<Type> &type,
+                                   bool stopOnTypeDefs) const {
+    if (*returnType == *type ||
+        returnType.get()->usesType(type, stopOnTypeDefs)) {
         return true;
     }
 
     for (const auto &parameterType : parametersTypes) {
-        if (*parameterType == *type) {
+        if (*parameterType == *type ||
+            parameterType.get()->usesType(type, stopOnTypeDefs)) {
             return true;
         }
     }

--- a/bindgen/ir/types/FunctionPointerType.h
+++ b/bindgen/ir/types/FunctionPointerType.h
@@ -13,7 +13,8 @@ class FunctionPointerType : public Type {
 
     ~FunctionPointerType() override = default;
 
-    bool usesType(const std::shared_ptr<Type> &type) const override;
+    bool usesType(const std::shared_ptr<Type> &type,
+                  bool stopOnTypeDefs) const override;
 
     std::string str() const override;
 

--- a/bindgen/ir/types/PointerType.cpp
+++ b/bindgen/ir/types/PointerType.cpp
@@ -7,8 +7,10 @@ std::string PointerType::str() const {
     return "native.Ptr[" + type->str() + "]";
 }
 
-bool PointerType::usesType(const std::shared_ptr<Type> &type) const {
-    return *this->type == *type;
+bool PointerType::usesType(const std::shared_ptr<Type> &type,
+                           bool stopOnTypeDefs) const {
+    return *this->type == *type ||
+           this->type.get()->usesType(type, stopOnTypeDefs);
 }
 
 bool PointerType::operator==(const Type &other) const {

--- a/bindgen/ir/types/PointerType.h
+++ b/bindgen/ir/types/PointerType.h
@@ -9,7 +9,8 @@ class PointerType : public Type {
 
     ~PointerType() override = default;
 
-    bool usesType(const std::shared_ptr<Type> &type) const override;
+    bool usesType(const std::shared_ptr<Type> &type,
+                  bool stopOnTypeDefs) const override;
 
     std::string str() const override;
 

--- a/bindgen/ir/types/PrimitiveType.cpp
+++ b/bindgen/ir/types/PrimitiveType.cpp
@@ -7,7 +7,8 @@ std::string PrimitiveType::str() const { return handleReservedWords(type); }
 
 std::string PrimitiveType::getType() const { return type; }
 
-bool PrimitiveType::usesType(const std::shared_ptr<Type> &type) const {
+bool PrimitiveType::usesType(const std::shared_ptr<Type> &type,
+                             bool stopOnTypeDefs) const {
     return false;
 }
 

--- a/bindgen/ir/types/PrimitiveType.h
+++ b/bindgen/ir/types/PrimitiveType.h
@@ -13,7 +13,8 @@ class PrimitiveType : public Type {
 
     std::string getType() const;
 
-    bool usesType(const std::shared_ptr<Type> &type) const override;
+    bool usesType(const std::shared_ptr<Type> &type,
+                  bool stopOnTypeDefs) const override;
 
     std::string str() const override;
 

--- a/bindgen/ir/types/Type.cpp
+++ b/bindgen/ir/types/Type.cpp
@@ -2,7 +2,10 @@
 
 std::string Type::str() const { return ""; }
 
-bool Type::usesType(const std::shared_ptr<Type> &type) const { return false; }
+bool Type::usesType(const std::shared_ptr<Type> &type,
+                    bool stopOnTypeDefs) const {
+    return false;
+}
 
 bool Type::operator==(const Type &other) const { return false; }
 

--- a/bindgen/ir/types/Type.h
+++ b/bindgen/ir/types/Type.h
@@ -13,7 +13,15 @@ class Type {
 
     virtual std::string str() const;
 
-    virtual bool usesType(const std::shared_ptr<Type> &type) const;
+    /**
+     * @param stopOnTypeDefs if this parameter is true then TypeDefs instances
+     *                       will not be checked. This parameter is needed when
+     *                       usages of TypeDefs are checked, it helps to avoid
+     *                       false positives when usages if aliases for the
+     *                       typedef are found.
+     */
+    virtual bool usesType(const std::shared_ptr<Type> &type,
+                          bool stopOnTypeDefs) const;
 
     virtual bool operator==(const Type &other) const;
 


### PR DESCRIPTION
Fixes to #109

Fixes Function::usesType method
Do not search usages of typedef in other typedefs because result will be false positive