### PR TITLE
Small refactoring of StructOrUnion class

### DIFF
--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -32,7 +32,7 @@ void IR::addEnum(std::string name, const std::string &type,
     }
 }
 
-void IR::addStruct(std::string name, std::vector<Field *> fields,
+void IR::addStruct(std::string name, std::vector<std::shared_ptr<Field>> fields,
                    uint64_t typeSize, std::shared_ptr<Location> location) {
     std::shared_ptr<Struct> s = std::make_shared<Struct>(
         name, std::move(fields), typeSize, std::move(location));
@@ -46,7 +46,7 @@ void IR::addStruct(std::string name, std::vector<Field *> fields,
     }
 }
 
-void IR::addUnion(std::string name, std::vector<Field *> fields,
+void IR::addUnion(std::string name, std::vector<std::shared_ptr<Field>> fields,
                   uint64_t maxSize, std::shared_ptr<Location> location) {
     std::shared_ptr<Union> u = std::make_shared<Union>(
         name, std::move(fields), maxSize, std::move(location));

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -34,10 +34,10 @@ class IR {
                  std::vector<Enumerator> enumerators,
                  std::shared_ptr<Location> location);
 
-    void addStruct(std::string name, std::vector<Field *> fields,
+    void addStruct(std::string name, std::vector<std::shared_ptr<Field>> fields,
                    uint64_t typeSize, std::shared_ptr<Location> location);
 
-    void addUnion(std::string name, std::vector<Field *> fields,
+    void addUnion(std::string name, std::vector<std::shared_ptr<Field>> fields,
                   uint64_t maxSize, std::shared_ptr<Location> location);
 
     void addLiteralDefine(std::string name, std::string literal,

--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -38,18 +38,13 @@ std::string Field::generateGetter(int fieldIndex) {
     return s.str();
 }
 
-StructOrUnion::StructOrUnion(std::string name, std::vector<Field *> fields,
+StructOrUnion::StructOrUnion(std::string name,
+                             std::vector<std::shared_ptr<Field>> fields,
                              std::shared_ptr<Location> location)
     : name(std::move(name)), fields(std::move(fields)),
       location(std::move(location)) {}
 
 std::string StructOrUnion::getName() const { return name; }
-
-StructOrUnion::~StructOrUnion() {
-    for (const auto &field : fields) {
-        delete field;
-    }
-}
 
 bool StructOrUnion::equals(const StructOrUnion &other) const {
     if (this == &other) {
@@ -77,8 +72,8 @@ std::shared_ptr<Location> StructOrUnion::getLocation() const {
     return location;
 }
 
-Struct::Struct(std::string name, std::vector<Field *> fields, uint64_t typeSize,
-               std::shared_ptr<Location> location)
+Struct::Struct(std::string name, std::vector<std::shared_ptr<Field>> fields,
+               uint64_t typeSize, std::shared_ptr<Location> location)
     : StructOrUnion(std::move(name), std::move(fields), std::move(location)),
       typeSize(typeSize) {}
 
@@ -163,8 +158,8 @@ bool Struct::operator==(const Type &other) const {
     return false;
 }
 
-Union::Union(std::string name, std::vector<Field *> fields, uint64_t maxSize,
-             std::shared_ptr<Location> location)
+Union::Union(std::string name, std::vector<std::shared_ptr<Field>> fields,
+             uint64_t maxSize, std::shared_ptr<Location> location)
     : StructOrUnion(std::move(name), std::move(fields), std::move(location)),
       ArrayType(std::make_shared<PrimitiveType>("Byte"), maxSize) {}
 

--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -20,10 +20,8 @@ class Field : public TypeAndName {
 
 class StructOrUnion {
   public:
-    StructOrUnion(std::string name, std::vector<Field *> fields,
+    StructOrUnion(std::string name, std::vector<std::shared_ptr<Field>> fields,
                   std::shared_ptr<Location> location);
-
-    ~StructOrUnion();
 
     virtual std::shared_ptr<TypeDef> generateTypeDef() = 0;
 
@@ -39,7 +37,7 @@ class StructOrUnion {
 
   protected:
     std::string name;
-    std::vector<Field *> fields;
+    std::vector<std::shared_ptr<Field>> fields;
     std::shared_ptr<Location> location;
 };
 
@@ -47,8 +45,8 @@ class Struct : public StructOrUnion,
                public Type,
                public std::enable_shared_from_this<Struct> {
   public:
-    Struct(std::string name, std::vector<Field *> fields, uint64_t typeSize,
-           std::shared_ptr<Location> location);
+    Struct(std::string name, std::vector<std::shared_ptr<Field>> fields,
+           uint64_t typeSize, std::shared_ptr<Location> location);
 
     std::shared_ptr<TypeDef> generateTypeDef() override;
 
@@ -77,8 +75,8 @@ class Union : public StructOrUnion,
               public ArrayType,
               public std::enable_shared_from_this<Union> {
   public:
-    Union(std::string name, std::vector<Field *> fields, uint64_t maxSize,
-          std::shared_ptr<Location> location);
+    Union(std::string name, std::vector<std::shared_ptr<Field>> fields,
+          uint64_t maxSize, std::shared_ptr<Location> location);
 
     std::shared_ptr<TypeDef> generateTypeDef() override;
 

--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -12,10 +12,6 @@
 class Field : public TypeAndName {
   public:
     Field(std::string name, std::shared_ptr<Type> type);
-
-    std::string generateSetter(int fieldIndex);
-
-    std::string generateGetter(int fieldIndex);
 };
 
 class StructOrUnion {
@@ -65,6 +61,10 @@ class Struct : public StructOrUnion,
     std::string str() const override;
 
     bool operator==(const Type &other) const override;
+
+    std::string generateSetter(unsigned fieldIndex) const;
+
+    std::string generateGetter(unsigned fieldIndex) const;
 
   private:
     /* type size is needed if number of fields is bigger than 22 */

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -101,7 +101,7 @@ bool TreeVisitor::VisitRecordDecl(clang::RecordDecl *record) {
 void TreeVisitor::handleUnion(clang::RecordDecl *record, std::string name) {
     uint64_t maxSize = 0;
 
-    std::vector<Field *> fields;
+    std::vector<std::shared_ptr<Field>> fields;
 
     for (const clang::FieldDecl *field : record->fields()) {
         uint64_t sizeInBits = astContext->getTypeSize(field->getType());
@@ -111,7 +111,7 @@ void TreeVisitor::handleUnion(clang::RecordDecl *record, std::string name) {
         std::shared_ptr<Type> ftype =
             typeTranslator.translate(field->getType(), &name);
 
-        fields.push_back(new Field(fname, ftype));
+        fields.push_back(std::make_shared<Field>(fname, ftype));
     }
 
     ir.addUnion(name, std::move(fields), maxSize, getLocation(record));
@@ -128,12 +128,13 @@ void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
     }
 
     int fieldCnt = 0;
-    std::vector<Field *> fields;
+    std::vector<std::shared_ptr<Field>> fields;
 
     for (const clang::FieldDecl *field : record->fields()) {
         std::shared_ptr<Type> ftype =
             typeTranslator.translate(field->getType(), &name);
-        fields.push_back(new Field(field->getNameAsString(), ftype));
+        fields.push_back(
+            std::make_shared<Field>(field->getNameAsString(), ftype));
 
         cycleDetection.AddDependency(newName, field->getType());
 


### PR DESCRIPTION
`fields` field stores shared_ptr.
Move generateGetter and generateSetter methods from Field class to Struct because the methods should not be used in Union class.