### PR TITLE
Do not generate helper methods for packed structs that are represented as CStruct

### DIFF
--- a/bindgen/ir/IR.cpp
+++ b/bindgen/ir/IR.cpp
@@ -33,9 +33,10 @@ void IR::addEnum(std::string name, const std::string &type,
 }
 
 void IR::addStruct(std::string name, std::vector<std::shared_ptr<Field>> fields,
-                   uint64_t typeSize, std::shared_ptr<Location> location) {
+                   uint64_t typeSize, std::shared_ptr<Location> location,
+                   bool isPacked) {
     std::shared_ptr<Struct> s = std::make_shared<Struct>(
-        name, std::move(fields), typeSize, std::move(location));
+        name, std::move(fields), typeSize, std::move(location), isPacked);
     structs.push_back(s);
     std::shared_ptr<TypeDef> typeDef = getTypeDefWithName("struct_" + name);
     if (typeDef) {

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -35,7 +35,8 @@ class IR {
                  std::shared_ptr<Location> location);
 
     void addStruct(std::string name, std::vector<std::shared_ptr<Field>> fields,
-                   uint64_t typeSize, std::shared_ptr<Location> location);
+                   uint64_t typeSize, std::shared_ptr<Location> location,
+                   bool isPacked);
 
     void addUnion(std::string name, std::vector<std::shared_ptr<Field>> fields,
                   uint64_t maxSize, std::shared_ptr<Location> location);

--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -42,7 +42,8 @@ class Struct : public StructOrUnion,
                public std::enable_shared_from_this<Struct> {
   public:
     Struct(std::string name, std::vector<std::shared_ptr<Field>> fields,
-           uint64_t typeSize, std::shared_ptr<Location> location);
+           uint64_t typeSize, std::shared_ptr<Location> location,
+           bool isPacked);
 
     std::shared_ptr<TypeDef> generateTypeDef() override;
 
@@ -69,6 +70,9 @@ class Struct : public StructOrUnion,
   private:
     /* type size is needed if number of fields is bigger than 22 */
     uint64_t typeSize;
+    bool isPacked;
+
+    bool isRepresentedAsStruct() const;
 };
 
 class Union : public StructOrUnion,

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -149,7 +149,8 @@ void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
     uint64_t sizeInBits = astContext->getTypeSize(record->getTypeForDecl());
     assert(sizeInBits % 8 == 0);
 
-    ir.addStruct(name, std::move(fields), sizeInBits / 8, getLocation(record));
+    ir.addStruct(name, std::move(fields), sizeInBits / 8, getLocation(record),
+                 record->hasAttr<clang::PackedAttr>());
 }
 
 bool TreeVisitor::VisitVarDecl(clang::VarDecl *varDecl) {

--- a/tests/samples/Struct.h
+++ b/tests/samples/Struct.h
@@ -56,6 +56,10 @@ struct structWithAnonymousStruct {
     } anonymousStruct;
 };
 
+struct __attribute__((__packed__)) packedStruct { // no helper methods
+    char a;
+};
+
 char getCharFromAnonymousStruct(struct structWithAnonymousStruct *s);
 
 char getIntFromAnonymousStruct(struct structWithAnonymousStruct *s);

--- a/tests/samples/Struct.scala
+++ b/tests/samples/Struct.scala
@@ -13,6 +13,7 @@ object Struct {
   type point_s = native.Ptr[struct_point]
   type struct_bigStruct = native.CArray[Byte, native.Nat.Digit[native.Nat._1, native.Nat.Digit[native.Nat._1, native.Nat._2]]]
   type struct_structWithAnonymousStruct = native.CStruct2[native.CInt, native.CArray[Byte, native.Nat._8]]
+  type struct_packedStruct = native.CStruct1[native.CChar]
   def setPoints(points: native.Ptr[struct_points], x1: native.CInt, y1: native.CInt, x2: native.CInt, y2: native.CInt): Unit = native.extern
   def getPoint(points: native.Ptr[struct_points], pointIndex: enum_pointIndex): native.CInt = native.extern
   def createPoint(): native.Ptr[struct_point] = native.extern


### PR DESCRIPTION
Because these helper methods are most likely wrong.