### PR TITLE
[WIP] Represent bit fields as arrays

### DIFF
--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -13,15 +13,15 @@ class Field : public TypeAndName {
   public:
     Field(std::string name, std::shared_ptr<Type> type);
 
-    Field(std::string name, std::shared_ptr<Type> type, uint64_t offset);
+    Field(std::string name, std::shared_ptr<Type> type, uint64_t offsetInBits);
 
-    uint64_t getOffset() const;
+    uint64_t getOffsetInBits() const;
 
   protected:
     /**
      * Offset in bytes from address of struct/union.
      */
-    uint64_t offset = 0;
+    uint64_t offsetInBits = 0;
 };
 
 class StructOrUnion {
@@ -99,6 +99,8 @@ class Struct : public StructOrUnion,
     std::string generateSetterForArrayRepresentation(unsigned fieldIndex) const;
 
     std::string generateGetterForArrayRepresentation(unsigned fieldIndex) const;
+
+    bool isBitField() const;
 };
 
 class Union : public StructOrUnion,

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -135,9 +135,8 @@ void TreeVisitor::handleStruct(clang::RecordDecl *record, std::string name) {
             typeTranslator.translate(field->getType(), &name);
         uint64_t recordOffsetInBits =
             recordLayout.getFieldOffset(field->getFieldIndex());
-        assert(recordOffsetInBits % 8 == 0);
-        fields.push_back(std::make_shared<Field>(
-            field->getNameAsString(), ftype, recordOffsetInBits / 8));
+        fields.push_back(std::make_shared<Field>(field->getNameAsString(),
+                                                 ftype, recordOffsetInBits));
 
         cycleDetection.AddDependency(newName, field->getType());
     }

--- a/tests/samples/Struct.h
+++ b/tests/samples/Struct.h
@@ -60,6 +60,13 @@ struct __attribute__((__packed__)) packedStruct { // no helper methods
     char a;
 };
 
+struct bitFieldStruct { // no helper methods
+    unsigned char b1 : 3;
+    unsigned char : 0; // start a new byte
+    unsigned char b2 : 6;
+    unsigned char b3 : 2;
+};
+
 char getCharFromAnonymousStruct(struct structWithAnonymousStruct *s);
 
 char getIntFromAnonymousStruct(struct structWithAnonymousStruct *s);

--- a/tests/samples/Struct.scala
+++ b/tests/samples/Struct.scala
@@ -14,6 +14,7 @@ object Struct {
   type struct_bigStruct = native.CArray[Byte, native.Nat.Digit[native.Nat._1, native.Nat.Digit[native.Nat._1, native.Nat._2]]]
   type struct_structWithAnonymousStruct = native.CStruct2[native.CInt, native.CArray[Byte, native.Nat._8]]
   type struct_packedStruct = native.CStruct1[native.CChar]
+  type struct_bitFieldStruct = native.CArray[Byte, native.Nat._2]
   type enum_struct_op = native.CUnsignedInt
   def setPoints(points: native.Ptr[struct_points], x1: native.CInt, y1: native.CInt, x2: native.CInt, y2: native.CInt): Unit = native.extern
   def getPoint(points: native.Ptr[struct_points], pointIndex: enum_pointIndex): native.CInt = native.extern


### PR DESCRIPTION
If a struct is a bit field then it is represented as `CArray` type and no helper methods are generated.

Implementation of `Struct::isBitField` is far from perfect, it simply checks is there an offset that is not divisible by 8. At least it should check whether all types fit into gaps between offsets, but it still will not guarantee that layout will match Scala Native struct layout.