### PR TITLE
Inheritance cleanup

### DIFF
--- a/bindgen/ir/Enum.h
+++ b/bindgen/ir/Enum.h
@@ -18,7 +18,7 @@ class Enumerator {
     int64_t value;
 };
 
-class Enum : public PrimitiveType, public std::enable_shared_from_this<Enum> {
+class Enum : public PrimitiveType {
   public:
     Enum(std::string name, std::string type,
          std::vector<Enumerator> enumerators,

--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -24,7 +24,7 @@ class Field : public TypeAndName {
     uint64_t offsetInBits = 0;
 };
 
-class StructOrUnion {
+class StructOrUnion : public virtual Type {
   public:
     StructOrUnion(std::string name, std::vector<std::shared_ptr<Field>> fields,
                   std::shared_ptr<Location> location);
@@ -47,9 +47,7 @@ class StructOrUnion {
     std::shared_ptr<Location> location;
 };
 
-class Struct : public StructOrUnion,
-               public Type,
-               public std::enable_shared_from_this<Struct> {
+class Struct : public StructOrUnion {
   public:
     Struct(std::string name, std::vector<std::shared_ptr<Field>> fields,
            uint64_t typeSize, std::shared_ptr<Location> location, bool isPacked,
@@ -103,9 +101,7 @@ class Struct : public StructOrUnion,
     std::string generateGetterForArrayRepresentation(unsigned fieldIndex) const;
 };
 
-class Union : public StructOrUnion,
-              public ArrayType,
-              public std::enable_shared_from_this<Union> {
+class Union : public StructOrUnion, public ArrayType {
   public:
     Union(std::string name, std::vector<std::shared_ptr<Field>> fields,
           uint64_t maxSize, std::shared_ptr<Location> location);

--- a/bindgen/ir/types/ArrayType.h
+++ b/bindgen/ir/types/ArrayType.h
@@ -3,11 +3,9 @@
 
 #include "Type.h"
 
-class ArrayType : public Type {
+class ArrayType : public virtual Type {
   public:
     ArrayType(std::shared_ptr<Type> elementsType, uint64_t size);
-
-    ~ArrayType() override = default;
 
     bool usesType(const std::shared_ptr<Type> &type,
                   bool stopOnTypeDefs) const override;

--- a/bindgen/ir/types/FunctionPointerType.h
+++ b/bindgen/ir/types/FunctionPointerType.h
@@ -11,8 +11,6 @@ class FunctionPointerType : public Type {
         const std::vector<std::shared_ptr<Type>> &parametersTypes,
         bool isVariadic);
 
-    ~FunctionPointerType() override = default;
-
     bool usesType(const std::shared_ptr<Type> &type,
                   bool stopOnTypeDefs) const override;
 

--- a/bindgen/ir/types/PointerType.h
+++ b/bindgen/ir/types/PointerType.h
@@ -7,8 +7,6 @@ class PointerType : public Type {
   public:
     explicit PointerType(std::shared_ptr<Type> type);
 
-    ~PointerType() override = default;
-
     bool usesType(const std::shared_ptr<Type> &type,
                   bool stopOnTypeDefs) const override;
 

--- a/bindgen/ir/types/Type.h
+++ b/bindgen/ir/types/Type.h
@@ -7,10 +7,8 @@
 /**
  * Base class for types.
  */
-class Type {
+class Type : public std::enable_shared_from_this<Type> {
   public:
-    virtual ~Type() = default;
-
     virtual std::string str() const = 0;
 
     /**


### PR DESCRIPTION
 * `shared_from_this` is available in all type classes
 * `StructOrUnion` inherits from `Type`