### PR TITLE
Reuse generated bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN set -x \
             g++ openjdk-8-jdk-headless sbt cmake make curl git \
             zlib1g-dev \
             libgc-dev libunwind8-dev libre2-dev \
+            nlohmann-json-dev \
  && rm -rf /var/lib/apt/lists/*
 
 ARG LLVM_VERSION=6.0

--- a/bindgen/CustomNames.h
+++ b/bindgen/CustomNames.h
@@ -1,0 +1,10 @@
+struct page {
+    char *content;
+    struct page *nextStruct;
+};
+
+struct book {
+    struct page *firstPage;
+};
+
+typedef int myInt;

--- a/bindgen/Main.cpp
+++ b/bindgen/Main.cpp
@@ -26,6 +26,10 @@ int main(int argc, const char *argv[]) {
     llvm::cl::opt<std::string> LinkName(
         "link", llvm::cl::cat(Category),
         llvm::cl::desc("Library to link with, e.g. -luv for libuv"));
+    llvm::cl::opt<std::string> ReuseBindingsConfig(
+        "binding-config", llvm::cl::cat(Category),
+        llvm::cl::desc("Path to a config file that contains the information "
+                       "about bindings that should be reused"));
     clang::tooling::CommonOptionsParser op(argc, argv, Category);
     clang::tooling::ClangTool Tool(op.getCompilations(),
                                    op.getSourcePathList());
@@ -61,6 +65,11 @@ int main(int argc, const char *argv[]) {
 
     std::string resolved = getRealPath(op.getSourcePathList()[0].c_str());
     LocationManager locationManager(resolved);
+
+    auto reuseBindingsConfig = ReuseBindingsConfig.getValue();
+    if (!reuseBindingsConfig.empty()) {
+        locationManager.loadConfig(reuseBindingsConfig);
+    }
 
     IR ir(libName, linkName, objectName, Package.getValue(), locationManager);
 

--- a/bindgen/Utils.h
+++ b/bindgen/Utils.h
@@ -49,6 +49,13 @@ static inline bool startsWith(const std::string &str,
     return str.substr(0, prefix.size()) == prefix;
 }
 
+/**
+ * @return true if str ends with given prefix
+ */
+static inline bool endsWith(const std::string &str, const std::string &suffix) {
+    return str.substr(str.length() - suffix.size(), str.length()) == suffix;
+}
+
 template <typename T, typename PT> static inline bool isInstanceOf(PT *type) {
     auto *p = dynamic_cast<const T *>(type);
     return p != nullptr;

--- a/bindgen/ir/Function.h
+++ b/bindgen/ir/Function.h
@@ -18,8 +18,7 @@ class Function {
              std::vector<std::shared_ptr<Parameter>> parameters,
              std::shared_ptr<const Type> retType, bool isVariadic);
 
-    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
-                                         const Function &func);
+    std::string getDefinition(const LocationManager &locationManager) const;
 
     bool usesType(std::shared_ptr<const Type> type, bool stopOnTypeDefs,
                   std::vector<std::shared_ptr<const Type>> &visitedTypes) const;

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -153,21 +153,31 @@ class IR {
     /**
      * @return true if the type will be printed.
      *         Following types are not printed:
+     *         - Types that should be imported from other bindings
      *         - Unused types from included headers
-     *         - Unused typedefs from main header if they reference an opaque
-     *           type (if such typedef is used then true is returned but error
-     *           message is printed when bindings are generated)
      */
     bool
     shouldOutput(const std::shared_ptr<const LocatableType> &type,
                  std::vector<std::shared_ptr<const Type>> &visitedTypes) const;
 
     /**
-     * @tparam T Struct or Union
+     * @return true if typedef will be printed.
+     *         Following typedefs are not printed:
+     *         - TypeDefs that should be imported from other bindings
+     *         - Unused typedefs from included headers
+     *         - Unused typedefs from main header if they reference an opaque
+     *           type
+     */
+    bool shouldOutputTypeDef(
+        const std::shared_ptr<const TypeDef> &typeDef,
+        std::vector<std::shared_ptr<const Type>> &visitedTypes) const;
+
+    /**
+     * @tparam T one of LocatableType
      */
     template <typename T>
-    bool hasOutputtedDeclaration(
-        const std::vector<std::shared_ptr<T>> &declarations) const;
+    bool
+    shouldOutputType(const std::vector<std::shared_ptr<T>> &declarations) const;
 
     std::string libName;    // name of the library
     std::string linkName;   // name of the library to link with

--- a/bindgen/ir/LiteralDefine.cpp
+++ b/bindgen/ir/LiteralDefine.cpp
@@ -4,11 +4,10 @@ LiteralDefine::LiteralDefine(std::string name, std::string literal,
                              std::shared_ptr<const Type> type)
     : Define(std::move(name)), literal(std::move(literal)), type(type) {}
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
-                              const LiteralDefine &literalDefine) {
-    s << "  val " << literalDefine.name << ": " << literalDefine.type->str()
-      << " = " << literalDefine.literal << "\n";
-    return s;
+std::string
+LiteralDefine::getDefinition(const LocationManager &locationManager) const {
+    return "  val " + name + ": " + type->str(locationManager) + " = " +
+           literal + "\n";
 }
 
 bool LiteralDefine::usesType(

--- a/bindgen/ir/LiteralDefine.h
+++ b/bindgen/ir/LiteralDefine.h
@@ -10,8 +10,7 @@ class LiteralDefine : public Define {
     LiteralDefine(std::string name, std::string literal,
                   std::shared_ptr<const Type> type);
 
-    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
-                                         const LiteralDefine &literalDefine);
+    std::string getDefinition(const LocationManager &locationManager) const;
 
     bool usesType(const std::shared_ptr<const Type> &type, bool stopOnTypeDefs,
                   std::vector<std::shared_ptr<const Type>> &visitedTypes) const;

--- a/bindgen/ir/Location.h
+++ b/bindgen/ir/Location.h
@@ -12,7 +12,7 @@ class Location {
     int getLineNumber() const;
 
   private:
-    std::string path;
+    std::string path; // may be empty
     int lineNumber;
 };
 

--- a/bindgen/ir/LocationManager.cpp
+++ b/bindgen/ir/LocationManager.cpp
@@ -1,12 +1,138 @@
 #include "LocationManager.h"
+#include "../Utils.h"
+#include "Enum.h"
+#include "Struct.h"
+#include <fstream>
+#include <stdexcept>
 
 LocationManager::LocationManager(std::string mainHeaderPath)
     : mainHeaderPath(std::move(mainHeaderPath)) {}
 
 void LocationManager::loadConfig(const std::string &path) {
-    // TODO: implement
+    std::string realPath = getRealPath(path.c_str());
+
+    std::stringstream s;
+    std::ifstream input(realPath);
+    for (std::string line; getline(input, line);) {
+        s << line;
+    }
+    config = json::parse(s.str());
+    validateConfig(config);
+}
+
+void LocationManager::validateConfig(const json &config) const {
+    if (!config.is_object()) {
+        throw std::invalid_argument(
+            "Invalid configuration. Configuration should be an object.");
+    }
+    for (auto it = config.begin(); it != config.end(); ++it) {
+        std::string headerName = it.key();
+        if (headerName.empty()) {
+            throw std::invalid_argument("Invalid configuration. Header name "
+                                        "should not be an empty string.");
+        }
+        json headerEntry = it.value();
+        validateHeaderEntry(headerEntry);
+    }
+}
+
+void LocationManager::validateHeaderEntry(const json &headerEntry) const {
+    if (headerEntry.is_string()) {
+        std::string object = headerEntry.get<std::string>();
+        if (object.empty()) {
+            throw std::invalid_argument("Invalid configuration. Each header "
+                                        "entry should contain non-empty "
+                                        "value.");
+        }
+    } else if (headerEntry.is_object()) {
+        std::unordered_set<std::string> headerKeys = {"object", "names"};
+        validateKeys(headerEntry, headerKeys);
+        if (headerEntry.find("object") == headerEntry.end()) {
+            throw std::invalid_argument("Invalid configuration. Header entry "
+                                        "that is represented as an object "
+                                        "should contain 'object' property.");
+        }
+        json object = headerEntry["object"];
+        if (!object.is_string() || object.get<std::string>().empty()) {
+            throw std::invalid_argument("Invalid configuration. 'object' "
+                                        "property should be a not empty "
+                                        "string.");
+        }
+        if (headerEntry.find("name") != headerEntry.end()) {
+            validateNames(headerEntry["names"]);
+        }
+    } else {
+        throw std::invalid_argument("Invalid configuration. Header entry "
+                                    "should be a string or an object.");
+    }
+}
+
+void LocationManager::validateKeys(
+    const json &object, const std::unordered_set<std::string> &keys) const {
+    for (auto it = object.begin(); it != object.end(); ++it) {
+        if (keys.find(it.key()) == keys.end()) {
+            throw std::invalid_argument(
+                "Invalid configuration. Unknown key: '" + it.key() + "'.");
+        }
+    }
+}
+
+void LocationManager::validateNames(const json &names) const {
+    if (!names.is_object()) {
+        throw std::invalid_argument("Invalid configuration. Library property "
+                                    "'names' should be an object.");
+    }
+    for (auto it = names.begin(); it != names.end(); ++it) {
+        if (!it.value().is_string()) {
+            throw std::invalid_argument(
+                "Invalid configuration. property 'names'"
+                " should contain only string values.");
+        }
+    }
 }
 
 bool LocationManager::inMainFile(const Location &location) const {
     return location.getPath() == mainHeaderPath;
+}
+
+bool LocationManager::isImported(const Location &location) const {
+    if (location.getPath().empty()) {
+        return false;
+    }
+    json headerEntry = getHeaderEntry(location);
+    return !headerEntry.empty();
+}
+
+json LocationManager::getHeaderEntry(const Location &location) const {
+    for (auto it = config.begin(); it != config.end(); ++it) {
+        std::string pathToHeader = it.key();
+        if (startsWith(pathToHeader, "/")) {
+            /* full path */
+            if (location.getPath() == pathToHeader) {
+                return it.value();
+            }
+        } else if (endsWith(location.getPath(), "/" + pathToHeader)) {
+            return it.value();
+        }
+    }
+    return json::object();
+}
+
+std::string LocationManager::getImportedType(const Location &location,
+                                             const std::string &name) const {
+    json headerEntry = getHeaderEntry(location);
+    if (headerEntry.is_string()) {
+        return headerEntry.get<std::string>() + "." +
+               handleReservedWords(replaceChar(name, " ", "_"));
+    }
+    std::string scalaObject = headerEntry["object"];
+
+    if (headerEntry.find("names") != headerEntry.end()) {
+        /* name mapping */
+        json names = headerEntry["names"];
+        if (names.find(name) != names.end()) {
+            return scalaObject + "." + names[name].get<std::string>();
+        }
+    }
+    return scalaObject + "." + handleReservedWords(replaceChar(name, " ", "_"));
 }

--- a/bindgen/ir/LocationManager.h
+++ b/bindgen/ir/LocationManager.h
@@ -2,8 +2,12 @@
 #define SCALA_NATIVE_BINDGEN_LOCATIONMANAGER_H
 
 #include "Location.h"
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+
+using json = nlohmann::json;
 
 class LocationManager {
   public:
@@ -13,9 +17,28 @@ class LocationManager {
 
     bool inMainFile(const Location &location) const;
 
+    /**
+     * @return true if given type is imported from another Scala object
+     */
+    bool isImported(const Location &location) const;
+
+    std::string getImportedType(const Location &location,
+                                const std::string &name) const;
+
   private:
     std::string mainHeaderPath;
-    std::unordered_map<std::string, std::string> existingBindings;
+    json config;
+
+    json getHeaderEntry(const Location &location) const;
+
+    void validateConfig(const json &config) const;
+
+    void validateHeaderEntry(const json &headerEntry) const;
+
+    void validateNames(const json &names) const;
+
+    void validateKeys(const json &object,
+                      const std::unordered_set<std::string> &keys) const;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_LOCATIONMANAGER_H

--- a/bindgen/ir/Record.h
+++ b/bindgen/ir/Record.h
@@ -30,7 +30,8 @@ class Record : public LocatableType {
 
     virtual std::shared_ptr<TypeDef> generateTypeDef() = 0;
 
-    virtual std::string generateHelperClass() const = 0;
+    virtual std::string
+    generateHelperClass(const LocationManager &locationManager) const = 0;
 
     std::string getName() const;
 

--- a/bindgen/ir/Struct.h
+++ b/bindgen/ir/Struct.h
@@ -13,7 +13,8 @@ class Struct : public Record {
 
     std::shared_ptr<TypeDef> generateTypeDef() override;
 
-    std::string generateHelperClass() const override;
+    std::string
+    generateHelperClass(const LocationManager &locationManager) const override;
 
     std::string getTypeName() const override;
 
@@ -22,7 +23,7 @@ class Struct : public Record {
      */
     bool hasHelperMethods() const override;
 
-    std::string str() const override;
+    std::string str(const LocationManager &locationManager) const override;
 
     bool operator==(const Type &other) const override;
 
@@ -52,22 +53,26 @@ class Struct : public Record {
     /**
      * @return helper class methods for struct that is represented as CStruct.
      */
-    std::string generateHelperClassMethodsForStructRepresentation() const;
+    std::string generateHelperClassMethodsForStructRepresentation(
+        const LocationManager &locationManager) const;
 
     /**
      * @return helper class methods for struct that is represented as CArray.
      */
-    std::string generateHelperClassMethodsForArrayRepresentation() const;
+    std::string generateHelperClassMethodsForArrayRepresentation(
+        const LocationManager &locationManager) const;
 
-    std::string
-    generateSetterForStructRepresentation(unsigned fieldIndex) const;
+    std::string generateSetterForStructRepresentation(
+        unsigned fieldIndex, const LocationManager &locationManager) const;
 
-    std::string
-    generateGetterForStructRepresentation(unsigned fieldIndex) const;
+    std::string generateGetterForStructRepresentation(
+        unsigned fieldIndex, const LocationManager &locationManager) const;
 
-    std::string generateSetterForArrayRepresentation(unsigned fieldIndex) const;
+    std::string generateSetterForArrayRepresentation(
+        unsigned fieldIndex, const LocationManager &locationManager) const;
 
-    std::string generateGetterForArrayRepresentation(unsigned fieldIndex) const;
+    std::string generateGetterForArrayRepresentation(
+        unsigned fieldIndex, const LocationManager &locationManager) const;
 
     /**
      * This function is used to get type replacement for a field that should

--- a/bindgen/ir/TypeDef.h
+++ b/bindgen/ir/TypeDef.h
@@ -15,14 +15,13 @@ class TypeDef : public TypeAndName, public LocatableType {
     TypeDef(std::string name, std::shared_ptr<const Type> type,
             std::shared_ptr<Location> location);
 
-    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
-                                         const TypeDef &type);
+    std::string getDefinition(const LocationManager &locationManager) const;
 
     bool usesType(
         const std::shared_ptr<const Type> &type, bool stopOnTypeDefs,
         std::vector<std::shared_ptr<const Type>> &visitedTypes) const override;
 
-    std::string str() const override;
+    std::string str(const LocationManager &locationManager) const override;
 
     bool operator==(const Type &other) const override;
 
@@ -30,6 +29,11 @@ class TypeDef : public TypeAndName, public LocatableType {
      * @return true if the typedef is not generated alias for opaque type.
      */
     bool hasLocation() const;
+
+    /**
+     * @return true if typedef directly references an opaque type
+     */
+    bool wrapperForOpaqueType() const;
 
     bool findAllCycles(
         const std::shared_ptr<const Struct> &startStruct, CycleNode &cycleNode,

--- a/bindgen/ir/Union.h
+++ b/bindgen/ir/Union.h
@@ -16,7 +16,8 @@ class Union : public Record, public ArrayType {
 
     std::shared_ptr<TypeDef> generateTypeDef() override;
 
-    std::string generateHelperClass() const override;
+    std::string
+    generateHelperClass(const LocationManager &locationManager) const override;
 
     bool operator==(const Type &other) const override;
 
@@ -27,9 +28,11 @@ class Union : public Record, public ArrayType {
         std::vector<std::shared_ptr<const Type>> &visitedTypes) const override;
 
   private:
-    std::string generateGetter(const std::shared_ptr<Field> &field) const;
+    std::string generateGetter(const std::shared_ptr<Field> &field,
+                               const LocationManager &locationManager) const;
 
-    std::string generateSetter(const std::shared_ptr<Field> &field) const;
+    std::string generateSetter(const std::shared_ptr<Field> &field,
+                               const LocationManager &locationManager) const;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_UNION_H

--- a/bindgen/ir/VarDefine.cpp
+++ b/bindgen/ir/VarDefine.cpp
@@ -3,12 +3,11 @@
 VarDefine::VarDefine(std::string name, std::shared_ptr<Variable> variable)
     : Define(std::move(name)), variable(variable) {}
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
-                              const VarDefine &varDefine) {
-    s << "  @name(\"" << varDefine.variable->getName() << "\")\n"
-      << "  val " << varDefine.getName() << ": "
-      << varDefine.variable->getType()->str() << " = native.extern\n";
-    return s;
+std::string
+VarDefine::getDefinition(const LocationManager &locationManager) const {
+    return "  @name(\"" + variable->getName() + "\")\n" + "  val " + name +
+           ": " + variable->getType()->str(locationManager) +
+           " = native.extern\n";
 }
 
 bool VarDefine::hasIllegalUsageOfOpaqueType() const {

--- a/bindgen/ir/VarDefine.h
+++ b/bindgen/ir/VarDefine.h
@@ -11,6 +11,8 @@ class VarDefine : public Define {
   public:
     VarDefine(std::string name, std::shared_ptr<Variable> variable);
 
+    std::string getDefinition(const LocationManager &locationManager) const;
+
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
                                          const VarDefine &varDefine);
 

--- a/bindgen/ir/Variable.cpp
+++ b/bindgen/ir/Variable.cpp
@@ -4,10 +4,10 @@
 Variable::Variable(const std::string &name, std::shared_ptr<const Type> type)
     : TypeAndName(name, type) {}
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Variable &variable) {
-    s << "  val " << variable.getName() << ": " << variable.getType()->str()
-      << " = native.extern\n";
-    return s;
+std::string
+Variable::getDefinition(const LocationManager &locationManager) const {
+    return "  val " + name + ": " + type->str(locationManager) +
+           " = native.extern\n";
 }
 
 bool Variable::hasIllegalUsageOfOpaqueType() const {

--- a/bindgen/ir/Variable.h
+++ b/bindgen/ir/Variable.h
@@ -8,8 +8,7 @@ class Variable : public TypeAndName {
   public:
     Variable(const std::string &name, std::shared_ptr<const Type> type);
 
-    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
-                                         const Variable &variable);
+    std::string getDefinition(const LocationManager &locationManager) const;
 
     bool hasIllegalUsageOfOpaqueType() const;
 };

--- a/bindgen/ir/types/ArrayType.cpp
+++ b/bindgen/ir/types/ArrayType.cpp
@@ -5,8 +5,8 @@
 ArrayType::ArrayType(std::shared_ptr<const Type> elementsType, uint64_t size)
     : size(size), elementsType(std::move(elementsType)) {}
 
-std::string ArrayType::str() const {
-    return "native.CArray[" + elementsType->str() + ", " +
+std::string ArrayType::str(const LocationManager &locationManager) const {
+    return "native.CArray[" + elementsType->str(locationManager) + ", " +
            uint64ToScalaNat(size) + "]";
 }
 

--- a/bindgen/ir/types/ArrayType.h
+++ b/bindgen/ir/types/ArrayType.h
@@ -11,7 +11,7 @@ class ArrayType : public virtual Type {
         const std::shared_ptr<const Type> &type, bool stopOnTypeDefs,
         std::vector<std::shared_ptr<const Type>> &visitedTypes) const override;
 
-    std::string str() const override;
+    std::string str(const LocationManager &locationManager) const override;
 
     bool operator==(const Type &other) const override;
 

--- a/bindgen/ir/types/FunctionPointerType.cpp
+++ b/bindgen/ir/types/FunctionPointerType.cpp
@@ -8,18 +8,19 @@ FunctionPointerType::FunctionPointerType(
     : returnType(std::move(returnType)), parametersTypes(parametersTypes),
       isVariadic(isVariadic) {}
 
-std::string FunctionPointerType::str() const {
+std::string
+FunctionPointerType::str(const LocationManager &locationManager) const {
     std::stringstream ss;
     ss << "native.CFunctionPtr" << parametersTypes.size() << "[";
 
     for (const auto &parameterType : parametersTypes) {
-        ss << parameterType->str() << ", ";
+        ss << parameterType->str(locationManager) << ", ";
     }
 
     if (isVariadic) {
         ss << "native.CVararg, ";
     }
-    ss << returnType->str() << "]";
+    ss << returnType->str(locationManager) << "]";
     return ss.str();
 }
 

--- a/bindgen/ir/types/FunctionPointerType.h
+++ b/bindgen/ir/types/FunctionPointerType.h
@@ -19,7 +19,7 @@ class FunctionPointerType : public Type {
         const std::shared_ptr<const Struct> &startStruct, CycleNode &cycleNode,
         std::vector<std::shared_ptr<const Type>> &visitedTypes) const override;
 
-    std::string str() const override;
+    std::string str(const LocationManager &locationManager) const override;
 
     bool operator==(const Type &other) const override;
 

--- a/bindgen/ir/types/PointerType.cpp
+++ b/bindgen/ir/types/PointerType.cpp
@@ -4,8 +4,8 @@
 PointerType::PointerType(std::shared_ptr<const Type> type)
     : type(std::move(type)) {}
 
-std::string PointerType::str() const {
-    return "native.Ptr[" + type->str() + "]";
+std::string PointerType::str(const LocationManager &locationManager) const {
+    return "native.Ptr[" + type->str(locationManager) + "]";
 }
 
 bool PointerType::usesType(

--- a/bindgen/ir/types/PointerType.h
+++ b/bindgen/ir/types/PointerType.h
@@ -15,7 +15,7 @@ class PointerType : public Type {
         const std::shared_ptr<const Struct> &startStruct, CycleNode &cycleNode,
         std::vector<std::shared_ptr<const Type>> &visitedTypes) const override;
 
-    std::string str() const override;
+    std::string str(const LocationManager &locationManager) const override;
 
     bool operator==(const Type &other) const override;
 

--- a/bindgen/ir/types/PrimitiveType.cpp
+++ b/bindgen/ir/types/PrimitiveType.cpp
@@ -4,7 +4,9 @@
 
 PrimitiveType::PrimitiveType(std::string type) : type(std::move(type)) {}
 
-std::string PrimitiveType::str() const { return handleReservedWords(type); }
+std::string PrimitiveType::str(const LocationManager &locationManager) const {
+    return handleReservedWords(type);
+}
 
 std::string PrimitiveType::getType() const { return type; }
 

--- a/bindgen/ir/types/PrimitiveType.h
+++ b/bindgen/ir/types/PrimitiveType.h
@@ -17,7 +17,7 @@ class PrimitiveType : virtual public Type {
         const std::shared_ptr<const Type> &type, bool stopOnTypeDefs,
         std::vector<std::shared_ptr<const Type>> &visitedTypes) const override;
 
-    std::string str() const override;
+    std::string str(const LocationManager &locationManager) const override;
 
     bool operator==(const Type &other) const override;
 

--- a/bindgen/ir/types/Type.h
+++ b/bindgen/ir/types/Type.h
@@ -1,6 +1,7 @@
 #ifndef SCALA_NATIVE_BINDGEN_TYPE_H
 #define SCALA_NATIVE_BINDGEN_TYPE_H
 
+#include "../LocationManager.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -21,7 +22,7 @@ struct CycleNode {
  */
 class Type : public std::enable_shared_from_this<Type> {
   public:
-    virtual std::string str() const = 0;
+    virtual std::string str(const LocationManager &locationManager) const = 0;
 
     /**
      * @param type search type.

--- a/bindgen/visitor/TreeVisitor.cpp
+++ b/bindgen/visitor/TreeVisitor.cpp
@@ -1,4 +1,5 @@
 #include "TreeVisitor.h"
+#include "../Utils.h"
 
 bool TreeVisitor::VisitFunctionDecl(clang::FunctionDecl *func) {
     if (!astContext->getSourceManager().isInMainFile(func->getLocation())) {

--- a/docs/src/paradox/command-line-usage/index.md
+++ b/docs/src/paradox/command-line-usage/index.md
@@ -14,12 +14,13 @@ scala-native-bindgen --name uv /usr/include/uv.h -- > uv.scala
 
 ## Bindgen Options
 
-| Option               | Description                                                                     |
+| Option               | Description
 |----------------------|---------------------------------------------------------------------------------|
-| `--link`             | Library to link with, e.g. `--link` uv for libuv.                               |
-| `--no-link`          | Library does not require linking.                                               |
-| `--name`             | Scala object name that contains bindings. Default value set to library name.    |
-| `--package`          | Package name of generated Scala file.                                           |
-| `--exclude-prefix`   | Functions and unused typedefs will be removed if their names have given prefix. |
-| `--extra-arg`        | Additional argument to append to the compiler command line.                     |
-| `--extra-arg-before` | Additional argument to prepend to the compiler command line.                    |
+| `--link`             | Library to link with, e.g. `--link` uv for libuv.
+| `--no-link`          | Library does not require linking.
+| `--name`             | Scala object name that contains bindings. Default value set to library name.
+| `--package`          | Package name of generated Scala file.
+| `--exclude-prefix`   | Functions and unused typedefs will be removed if their names have given prefix.
+| `--binding-config`   | Path to a config file that contains the information about bindings that should be reused. See @ref:[Integrating Bindings](../integrating-bindings/index.md) for more information.
+| `--extra-arg`        | Additional argument to append to the compiler command line.
+| `--extra-arg-before` | Additional argument to prepend to the compiler command line.

--- a/docs/src/paradox/index.md
+++ b/docs/src/paradox/index.md
@@ -4,6 +4,7 @@
 
 * [Obtaining Bindgen](obtaining-bindgen/index.md)
 * [Command Line Usage](command-line-usage/index.md)
+* [Integrating Bindings](integrating-bindings/index.md)
 * [Limitations](limitations/index.md)
 * [Using Generated Bindings](using-generated-bindings/README.md)
 

--- a/docs/src/paradox/integrating-bindings/index.md
+++ b/docs/src/paradox/integrating-bindings/index.md
@@ -1,0 +1,25 @@
+# Integrating Bindings
+
+To reuse already generated bindings create a `config.json` file that defines which headers correspond to which Scala objects:
+```json
+{
+  "_stdio.h": "scala.scalanative.native.stdio",
+  "/full/path/to/regexp4.h": "bindings.regexp4"
+}
+```
+
+Bindgen assumes that type names in header files match type names in generated binding (spaces in struct, union and enum
+names are replaces with underscores), but it is possible to specify custom names mapping:
+```json
+{
+  "hiredis.h": {
+    "object": "bindings.hiredis.hiredis",
+    "names": {
+      "redisContext": "Context"
+    }
+  }
+}
+```
+
+Provide a path to `config.json` to bindgen using `--binding-config` command-line option or `NativeBinding.bindingConfig`
+sbt plugin option (see @ref:[Using the sbt plugin](../obtaining-bindgen/sbt-plugin.md)).

--- a/docs/src/paradox/obtaining-bindgen/cmake.md
+++ b/docs/src/paradox/obtaining-bindgen/cmake.md
@@ -4,6 +4,7 @@ Building `scala-native-bindgen` requires the following tools and libraries:
 
  - [CMake] version 3.9 or higher
  - [LLVM] and [Clang] version 5.0 or 6.0.
+ - [nlohmann/json] version 3.1.2 or higher
 
 ```sh
 # On apt-based systems
@@ -52,3 +53,4 @@ sbt test
  [LLVM]: https://llvm.org/
  [Clang]: https://clang.llvm.org/
  [Scala Native setup guide]: http://www.scala-native.org/en/latest/user/setup.html
+ [nlohmann/json]: https://github.com/nlohmann/json

--- a/tests/samples/CustomNames.scala
+++ b/tests/samples/CustomNames.scala
@@ -1,0 +1,12 @@
+package org.scalanative.bindgen.samples
+
+import scala.scalanative._
+import scala.scalanative.native._
+
+@native.link("bindgentests")
+@native.extern
+object CustomNames {
+  type page = native.CStruct2[native.CString, native.Ptr[Byte]]
+  type book = native.CStruct1[native.Ptr[page]]
+  type MY_INT = native.CInt
+}

--- a/tests/samples/ReuseBindings.h
+++ b/tests/samples/ReuseBindings.h
@@ -1,0 +1,18 @@
+#include "Struct.h"
+#include "include/CustomNames.h"
+
+void useStruct(struct point *);
+
+point_s returnTypedef_point_s(); // struct point will be references instead of
+                                 // point_s because clang replaces the typedef
+point *returnTypedef_point();
+
+typedef struct bigStruct aliasForBigStruct;
+
+struct usesImportedEnum {
+    enum pointIndex index;
+};
+
+void readBook(struct book *book);
+
+myInt getMyInt();

--- a/tests/samples/ReuseBindings.json
+++ b/tests/samples/ReuseBindings.json
@@ -1,0 +1,11 @@
+{
+  "Struct.h": "org.scalanative.bindgen.samples.Struct",
+  "CustomNames.h": {
+    "object": "org.scalanative.bindgen.samples.CustomNames",
+    "names": {
+      "struct book": "book",
+      "struct page": "page",
+      "myInt": "MY_INT"
+    }
+  }
+}

--- a/tests/samples/ReuseBindings.scala
+++ b/tests/samples/ReuseBindings.scala
@@ -1,0 +1,29 @@
+package org.scalanative.bindgen.samples
+
+import scala.scalanative._
+import scala.scalanative.native._
+
+@native.link("bindgentests")
+@native.extern
+object ReuseBindings {
+  type aliasForBigStruct = org.scalanative.bindgen.samples.Struct.struct_bigStruct
+  type struct_usesImportedEnum = native.CStruct1[org.scalanative.bindgen.samples.Struct.enum_pointIndex]
+  def useStruct(anonymous0: native.Ptr[org.scalanative.bindgen.samples.Struct.struct_point]): Unit = native.extern
+  def returnTypedef_point_s(): native.Ptr[org.scalanative.bindgen.samples.Struct.struct_point] = native.extern
+  def returnTypedef_point(): native.Ptr[org.scalanative.bindgen.samples.Struct.point] = native.extern
+  def readBook(book: native.Ptr[org.scalanative.bindgen.samples.CustomNames.book]): Unit = native.extern
+  def getMyInt(): org.scalanative.bindgen.samples.CustomNames.MY_INT = native.extern
+}
+
+import ReuseBindings._
+
+object ReuseBindingsHelpers {
+
+  implicit class struct_usesImportedEnum_ops(val p: native.Ptr[struct_usesImportedEnum]) extends AnyVal {
+    def index: org.scalanative.bindgen.samples.Struct.enum_pointIndex = !p._1
+    def index_=(value: org.scalanative.bindgen.samples.Struct.enum_pointIndex): Unit = !p._1 = value
+  }
+
+  def struct_usesImportedEnum()(implicit z: native.Zone): native.Ptr[struct_usesImportedEnum] = native.alloc[struct_usesImportedEnum]
+}
+

--- a/tests/samples/include/CustomNames.h
+++ b/tests/samples/include/CustomNames.h
@@ -1,0 +1,10 @@
+struct page {
+    char *content;
+    struct page *nextStruct;
+};
+
+struct book {
+    struct page *firstPage;
+};
+
+typedef int myInt;

--- a/tests/src/test/scala/org/scalanative/bindgen/BindgenSpec.scala
+++ b/tests/src/test/scala/org/scalanative/bindgen/BindgenSpec.scala
@@ -24,11 +24,16 @@ class BindgenSpec extends FunSpec {
       it(s"should generate bindings for ${input.getName}") {
         val testName = input.getName.replace(".h", "")
         val expected = new File(inputDirectory, testName + ".scala")
-        val options = BindingOptions(input)
+        val config   = new File(inputDirectory, testName + ".json")
+        var options = BindingOptions(input)
           .name(testName)
           .link("bindgentests")
           .packageName("org.scalanative.bindgen.samples")
           .excludePrefix("__")
+
+        if (config.exists()) {
+          options = options.bindingConfig(config)
+        }
 
         bindgen.generate(options) match {
           case Right(binding) =>

--- a/tools/src/main/scala/org/scalanative/bindgen/Bindgen.scala
+++ b/tools/src/main/scala/org/scalanative/bindgen/Bindgen.scala
@@ -34,6 +34,7 @@ class Bindgen(val executable: File) {
             withArgs("--exclude-prefix", excludePrefix) ++
             withArgs("--extra-arg", extraArgs) ++
             withArgs("--extra-arg-before", extraArgsBefore) ++
+            withArgs("--binding-config", bindingConfig.map(_.getAbsolutePath)) ++
             Seq(header.getAbsolutePath, "--")
 
         val cmd    = Seq(executable.getAbsolutePath) ++ options

--- a/tools/src/main/scala/org/scalanative/bindgen/BindingOptions.scala
+++ b/tools/src/main/scala/org/scalanative/bindgen/BindingOptions.scala
@@ -36,6 +36,12 @@ sealed trait BindingOptions {
    */
   def extraArgsBefore(args: String*): BindingOptions
 
+  /**
+   * Reuse types from already generated bindings.
+   * @param config file that contains information about generated bindings.
+   */
+  def bindingConfig(config: File): BindingOptions
+
 }
 
 object BindingOptions {
@@ -51,7 +57,8 @@ object BindingOptions {
                                          excludePrefix: Option[String] = None,
                                          extraArgs: Seq[String] = Seq.empty,
                                          extraArgsBefore: Seq[String] =
-                                           Seq.empty)
+                                           Seq.empty,
+                                         bindingConfig: Option[File] = None)
       extends BindingOptions {
 
     override def link(library: String): BindingOptions = {
@@ -83,6 +90,11 @@ object BindingOptions {
       require(args.forall(_.nonEmpty),
               "All extra-args-before must be non-empty")
       copy(extraArgsBefore = extraArgsBefore ++ args)
+    }
+
+    override def bindingConfig(config: File): BindingOptions = {
+      require(config.exists(), s"Config file must exist: $config")
+      copy(bindingConfig = Some(config))
     }
 
   }


### PR DESCRIPTION
Closes #2

Compilation requires https://github.com/nlohmann/json library.

Format of config file changed to json. It is very similar to previous stdHeaders file, but it provides a way to specify custom names mapping:
```json
{
  "_stdio.h": "scala.scalanative.native.stdio",
  "hiredis.h": {
    "object": "bindings.hiredis.hiredis",
    "names": {
      "struct redisContext": "RedisContext"
    }
  }
}
```

To do:
- [x] validate config file
- [x] support custom name mapping (e.g `struct s` -> `s` instead of `struct_s`)
- [x] test function pointer type (clang replaces typedef with actual function pointer type, so it's not possible to reuse function pointer type)
- [x] update documentation
- [x] add the option to sbt plugin