### PR TITLE
Fix detection of cycles that contain one struct

### DIFF
--- a/bindgen/ir/Struct.cpp
+++ b/bindgen/ir/Struct.cpp
@@ -325,6 +325,11 @@ Struct::shouldFieldBreakCycle(const std::shared_ptr<Field> &field) const {
          * changed if this struct has the biggest name compared to other structs
          * in cycle that have fields of non-value type.
          */
+        if (baseNode.cycleNodes.empty()) {
+            /* field references containing struct */
+            structTypesThatShouldBeReplaced.push_back(
+                shared_from_base<Struct>());
+        }
         for (const auto &nextCycleNode : baseNode.cycleNodes) {
             std::vector<std::string> namesInCycle;
             if (hasBiggestName(nextCycleNode, namesInCycle)) {

--- a/tests/samples/Cycles.h
+++ b/tests/samples/Cycles.h
@@ -1,3 +1,8 @@
+struct node {
+    int value;
+    struct node *next;
+};
+
 struct b;
 struct c;
 

--- a/tests/samples/Cycles.scala
+++ b/tests/samples/Cycles.scala
@@ -6,6 +6,7 @@ import scala.scalanative.native._
 @native.link("bindgentests")
 @native.extern
 object Cycles {
+  type struct_node = native.CStruct2[native.CInt, native.Ptr[Byte]]
   type struct_b = native.CStruct1[native.Ptr[native.Ptr[Byte]]]
   type struct_a = native.CStruct1[native.Ptr[struct_b]]
   type struct_c = native.CStruct1[struct_a]
@@ -26,6 +27,15 @@ object Cycles {
 import Cycles._
 
 object CyclesHelpers {
+
+  implicit class struct_node_ops(val p: native.Ptr[struct_node]) extends AnyVal {
+    def value: native.CInt = !p._1
+    def value_=(value: native.CInt): Unit = !p._1 = value
+    def next: native.Ptr[struct_node] = (!p._2).cast[native.Ptr[struct_node]]
+    def next_=(value: native.Ptr[struct_node]): Unit = !p._2 = value.cast[native.Ptr[Byte]]
+  }
+
+  def struct_node()(implicit z: native.Zone): native.Ptr[struct_node] = native.alloc[struct_node]
 
   implicit class struct_a_ops(val p: native.Ptr[struct_a]) extends AnyVal {
     def bb: native.Ptr[struct_b] = !p._1


### PR DESCRIPTION
Bindgen failed to detect such structs:
```c
struct node {
    int value;
    struct node *next;
};
```