### PR TITLE
Use the builder from the tools project in the sbt plugin

### DIFF
--- a/docs/src/paradox/obtaining-bindgen/sbt-plugin.md
+++ b/docs/src/paradox/obtaining-bindgen/sbt-plugin.md
@@ -11,13 +11,7 @@ resolvers += Resolver.bintrayRepo("scala-native-bindgen", "maven")
 ```
 @@@
 
-Next configure the plugin using the settings scoped to either `Compile` or `Test`:
-
-|---------------------------|-------------------|
-|`nativeBindgenHeader`      | The C header file to read.
-|`nativeBindgenPackage`     | Package of the enclosing object. No package by default.
-|`name in nativeBindgen`    | Name of the enclosing object.
-|`nativeBindgenLink`        | Name of library to be linked.
+Next configure the plugin using the `nativeBindings` setting scoped to either `Compile` or `Test`. The `NativeBinding` type to configure each binding that should be generated. 
 
 @@@ note
 
@@ -37,15 +31,17 @@ Example settings:
 enablePlugins(ScalaNativeBindgenPlugin)
 inConfig(Compile)(
   Def.settings(
-    nativeBindgenHeader := (resourceDirectory in Compile).value / "header.h",
-    nativeBindgenPackage := Some("org.example.mylib"),
-    nativeBindgenLink := Some("mylib"), // Will pass `-lmylib` to the linker
-    nativeBindgenExclude := Some("__"),
-    name in nativeBindgen := "MyLib"
+    nativeBindings += {
+      NativeBinding((resourceDirectory in Compile).value / "header.h")
+        .name("MyLib")
+        .packageName("org.example.mylib")
+        .link("mylib"), // Will pass `-lmylib` to the linker
+        .excludePrefix("__")
+      }
   ))
 ```
 
-Running `nativeBindgen` will generate a file named `target/scala-2.x/src_managed/main/sbt-scala-native-bindgen//ScalaNativeBindgen.scala` containing something along the following lines:
+Running `nativeBindgen` will generate a file named `target/scala-2.x/src_managed/main/sbt-scala-native-bindgen/MyLib.scala` containing something along the following lines:
 
 ```scala
 package org.example.mylib

--- a/sbt-scala-native-bindgen/src/main/scala/org/scalanative/bindgen/sbt/ScalaNativeBindgenPlugin.scala
+++ b/sbt-scala-native-bindgen/src/main/scala/org/scalanative/bindgen/sbt/ScalaNativeBindgenPlugin.scala
@@ -6,7 +6,7 @@ import sbt.Keys._
 import java.nio.file.Files
 import java.nio.file.attribute.{PosixFileAttributeView, PosixFilePermission}
 
-import org.scalanative.bindgen.Bindgen
+import org.scalanative.bindgen.{Bindgen, BindingOptions}
 
 /**
  * Generate Scala bindings from C headers.
@@ -37,21 +37,20 @@ import org.scalanative.bindgen.Bindgen
  *
  * @example
  * {{{
- * nativeBindgenHeader in Compile := file("/usr/include/ctype.h")
- * nativeBindgenPackage in Compile := Some("org.example.app")
- * name in (Compile, nativeBindgen) := "ctype"
+ * nativeBindings += {
+ *   NativeBinding(file("/usr/include/uv.h"))
+ *     .name("uv")
+ *     .packageName("org.example.uv")
+ *     .link("uv"),
+ *     .excludePrefix("__")
+ * }
  * }}}
  */
 object ScalaNativeBindgenPlugin extends AutoPlugin {
 
   object autoImport {
-    case class NativeBinding(
-        name: String,
-        header: File,
-        packageName: Option[String],
-        link: Option[String],
-        excludePrefix: Option[String]
-    )
+    type NativeBinding = BindingOptions
+    val NativeBinding      = BindingOptions
     val ScalaNativeBindgen = config("scala-native-bindgen").hide
     val nativeBindgenPath =
       taskKey[File]("Path to the scala-native-bindgen executable")
@@ -105,14 +104,6 @@ object ScalaNativeBindgenPlugin extends AutoPlugin {
         }
       )
 
-  private implicit class BindgenOps(val bindgen: Bindgen) extends AnyVal {
-    def maybe[T](opt: Option[T], f: Bindgen => T => Bindgen): Bindgen =
-      opt match {
-        case None        => bindgen
-        case Some(value) => f(bindgen)(value)
-      }
-  }
-
   private val artifactName =
     Option(System.getProperty("os.name")).collect {
       case "Mac OS X" => "scala-native-bindgen-darwin"
@@ -126,34 +117,26 @@ object ScalaNativeBindgenPlugin extends AutoPlugin {
         sourceGenerators += Def.task { nativeBindgen.value },
         target in nativeBindgen := sourceManaged.value / "sbt-scala-native-bindgen",
         nativeBindgen := {
-          val bindgenPath     = nativeBindgenPath.value
-          val bindings        = nativeBindings.value
+          val bindgen         = Bindgen(nativeBindgenPath.value)
+          val optionsList     = nativeBindings.value
           val outputDirectory = (target in nativeBindgen).value
           val logger          = streams.value.log
 
-          bindings.map {
-            binding =>
-              val output = outputDirectory / s"${binding.name}.scala"
-              val result = Bindgen()
-                .bindgenExecutable(bindgenPath)
-                .header(binding.header)
-                .name(binding.name)
-                .maybe(binding.link, _.link)
-                .maybe(binding.packageName, _.packageName)
-                .maybe(binding.excludePrefix, _.excludePrefix)
-                .generate()
+          // FIXME: Check uniqueness of names.
 
-              result match {
+          optionsList.map {
+            case options: BindingOptions.Impl =>
+              bindgen.generate(options) match {
                 case Right(bindings) =>
+                  val output = outputDirectory / s"${bindings.name}.scala"
                   bindings.writeToFile(output)
                   bindings.errors.foreach(error => logger.error(error))
+                  output
                 case Left(errors) =>
                   errors.foreach(error => logger.error(error))
                   sys.error(
                     "scala-native-bindgen failed with non-zero exit code")
               }
-
-              output
           }
         }
       ))

--- a/sbt-scala-native-bindgen/src/sbt-test/bindgen/generate/build.sbt
+++ b/sbt-scala-native-bindgen/src/sbt-test/bindgen/generate/build.sbt
@@ -6,15 +6,12 @@ scalaVersion := "2.11.12"
 inConfig(Compile)(
   Def.settings(
     nativeBindgenPath := file(System.getProperty("bindgen.path")),
-    nativeBindings := Seq(
-      NativeBinding(
-        name = "stdlib",
-        header = (resourceDirectory in Compile).value / "stdlib.h",
-        packageName = Some("org.example.app.stdlib"),
-        link = None,
-        excludePrefix = Some("__")
-      )
-    )
+    nativeBindings += {
+      NativeBinding((resourceDirectory in Compile).value / "stdlib.h")
+        .name("stdlib")
+        .packageName("org.example.app.stdlib")
+        .excludePrefix("__")
+    }
   ))
 
 val nativeBindgenCustomTarget = SettingKey[File]("nativeBindgenCustomTarget")
@@ -23,13 +20,9 @@ nativeBindgenCustomTarget := baseDirectory.value / "src/main/scala/org/example"
 val nativeBindgenCoreBinding =
   SettingKey[NativeBinding]("nativeBindgenCoreBinding")
 nativeBindgenCoreBinding := {
-  NativeBinding(
-    name = "core",
-    header = (resourceDirectory in Compile).value / "core.h",
-    packageName = Some("org.example.app.core"),
-    link = Some("core"),
-    excludePrefix = None
-  )
+  NativeBinding((resourceDirectory in Compile).value / "core.h")
+    .packageName("org.example.app.core")
+    .link("core")
 }
 
 val StdlibOutput =
@@ -47,14 +40,14 @@ val StdlibOutput =
   """.stripMargin
 
 def assertFileContent(file: File, expected: String): Unit = {
-  val actual = IO.read(file).trim
+  val actual = IO.read(file).trim()
   if (actual != expected.trim) {
     println(s"== [ actual ${file.getName} ] ========")
     println(actual)
     println(s"== [ expected ${file.getName} ] ========")
-    println(expected.trim)
+    println(expected.trim())
   }
-  assert(actual == expected.trim)
+  assert(actual == expected.trim())
 }
 
 TaskKey[Unit]("checkSingle") := {

--- a/tests/src/test/scala/org/scalanative/bindgen/BindgenReportingSpec.scala
+++ b/tests/src/test/scala/org/scalanative/bindgen/BindgenReportingSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSpec
 class BindgenReportingSpec extends FunSpec {
   describe("Bindgen") {
 
-    val bindgenPath = System.getProperty("bindgen.path")
+    val bindgen = Bindgen(new File(System.getProperty("bindgen.path")))
 
     def writeToFile(file: File, input: String): Unit = {
       new PrintWriter(file) {
@@ -24,16 +24,13 @@ class BindgenReportingSpec extends FunSpec {
       try {
         writeToFile(tempFile, input)
 
-        val result = Bindgen()
-          .bindgenExecutable(new File(bindgenPath))
-          .header(tempFile)
+        val options = BindingOptions(tempFile)
           .name("BindgenTests")
           .link("bindgentests")
           .packageName("org.scalanative.bindgen.samples")
           .excludePrefix("__")
-          .generate()
 
-        result match {
+        bindgen.generate(options) match {
           case Right(binding) =>
             assert(binding.errors == errors)
           case Left(errors) =>

--- a/tools/src/main/scala/org/scalanative/bindgen/Bindgen.scala
+++ b/tools/src/main/scala/org/scalanative/bindgen/Bindgen.scala
@@ -6,141 +6,58 @@ import scala.collection.immutable.Seq
 import scala.collection.mutable.ListBuffer
 import scala.sys.process.{Process, ProcessLogger}
 
-sealed trait Bindgen {
+class Bindgen(val executable: File) {
 
   /**
-   * Set bindgen executable
-   */
-  def bindgenExecutable(executable: File): Bindgen
-
-  /**
-   * Set header file for which bindings will be generated
-   */
-  def header(header: File): Bindgen
-
-  /**
-   * Library to link with, e.g. -luv for libuv
-   */
-  def link(library: String): Bindgen
-
-  /**
-   * Name of Scala object that contains bindings.
-   * Default is set to library name.
-   */
-  def name(name: String): Bindgen
-
-  /**
-   * Package name of generated Scala file
-   */
-  def packageName(packageName: String): Bindgen
-
-  /**
-   * Declarations will be removed if their names
-   * contain given prefix
-   */
-  def excludePrefix(prefix: String): Bindgen
-
-  /**
-   * Additional argument to append to the compiler command line
-   */
-  def extraArg(args: String*): Bindgen
-
-  /**
-   * Additional argument to append to the compiler command line
-   */
-  def extraArgBefore(args: String*): Bindgen
-
-  /**
-   * Run binding generator
+   * Run binding generator using the given scala-native-bindgen executable.
    * @return errors if exit code was not 0, otherwise return bindings
    */
-  def generate(): Either[Seq[String], Bindings]
+  def generate(options: BindingOptions): Either[Seq[String], Bindings] = {
+    options match {
+      case impl: BindingOptions.Impl =>
+        import impl._
+
+        require(executable.exists, "The executable does not exist")
+
+        val nameOrLibrary = name.orElse(library)
+        require(nameOrLibrary.isDefined,
+                "Name must be specified when no library name is given")
+
+        def withArgs(arg: String, values: Iterable[String]) =
+          values.toSeq.flatMap(Seq(arg, _))
+
+        val options =
+          withArgs("--name", nameOrLibrary) ++
+            withArgs("--link", library) ++
+            library.fold(Seq("--no-link"))(_ => Seq.empty) ++
+            withArgs("--package", packageName) ++
+            withArgs("--exclude-prefix", excludePrefix) ++
+            withArgs("--extra-arg", extraArgs) ++
+            withArgs("--extra-arg-before", extraArgsBefore) ++
+            Seq(header.getAbsolutePath, "--")
+
+        val cmd    = Seq(executable.getAbsolutePath) ++ options
+        val stdout = ListBuffer[String]()
+        val stderr = ListBuffer[String]()
+        val nl     = System.lineSeparator()
+        val logger = ProcessLogger(stdout.+=, stderr.+=)
+
+        Process(cmd).!(logger) match {
+          case 0 =>
+            Right(
+              new Bindings(nameOrLibrary.get,
+                           stdout.mkString(nl),
+                           Seq(stderr: _*)))
+          case _ => Left(Seq(stderr: _*))
+        }
+
+      case _ => Left(Seq("Illtyped BindingOptions"))
+    }
+  }
+
 }
 
 object Bindgen {
-  def apply(): Bindgen = Impl()
-
-  private final case class Impl(executable: Option[File] = None,
-                                library: Option[String] = None,
-                                header: Option[File] = None,
-                                name: Option[String] = None,
-                                packageName: Option[String] = None,
-                                excludePrefix: Option[String] = None,
-                                extraArg: Seq[String] = Seq.empty,
-                                extraArgBefore: Seq[String] = Seq.empty)
-      extends Bindgen {
-
-    def bindgenExecutable(executable: File): Bindgen = {
-      require(executable.exists(), s"Executable does not exist: $executable")
-      copy(executable = Option(executable))
-    }
-
-    def header(header: File): Bindgen = {
-      require(header.exists(), s"Header file does not exist: $header")
-      copy(header = Option(header))
-    }
-
-    def link(library: String): Bindgen = {
-      require(library.nonEmpty, "Library must be non-empty")
-      copy(library = Option(library))
-    }
-
-    def name(name: String): Bindgen = {
-      require(name.nonEmpty, "Name must be non-empty")
-      copy(name = Option(name))
-    }
-
-    def packageName(packageName: String): Bindgen = {
-      require(packageName.nonEmpty, "Package name must be non-empty")
-      copy(packageName = Option(packageName))
-    }
-
-    def excludePrefix(prefix: String): Bindgen = {
-      require(prefix.nonEmpty, "Exclude prefix must be non-empty")
-      copy(excludePrefix = Option(prefix))
-    }
-
-    def extraArg(args: String*): Bindgen = {
-      require(args.forall(_.nonEmpty), "All extra-args must be non-empty")
-      copy(extraArg = extraArg ++ args)
-    }
-
-    def extraArgBefore(args: String*): Bindgen = {
-      require(args.forall(_.nonEmpty),
-              "All extra-args-before must be non-empty")
-      copy(extraArgBefore = extraArgBefore ++ args)
-    }
-
-    def generate(): Either[Seq[String], Bindings] = {
-      require(executable.isDefined, "The executable must be specified")
-      require(header.isDefined, "Header file must be specified")
-
-      val nameOrLibrary = name.orElse(library)
-      require(nameOrLibrary.isDefined,
-              "Name must be specified when no library name is given")
-
-      def withArgs(arg: String, values: Iterable[String]) =
-        values.toSeq.flatMap(Seq(arg, _))
-
-      val cmd = Seq(executable.get.getAbsolutePath) ++
-        withArgs("--name", nameOrLibrary) ++
-        withArgs("--link", library) ++
-        library.fold(Seq("--no-link"))(_ => Seq.empty) ++
-        withArgs("--package", packageName) ++
-        withArgs("--exclude-prefix", excludePrefix) ++
-        withArgs("--extra-arg", extraArg) ++
-        withArgs("--extra-arg-before", extraArgBefore) ++
-        Seq(header.get.getAbsolutePath, "--")
-
-      val stdout = ListBuffer[String]()
-      val stderr = ListBuffer[String]()
-      val nl     = System.lineSeparator()
-      val logger = ProcessLogger(stdout.+=, stderr.+=)
-
-      Process(cmd).!(logger) match {
-        case 0 => Right(new Bindings(stdout.mkString(nl), Seq(stderr: _*)))
-        case _ => Left(Seq(stderr: _*))
-      }
-    }
-  }
+  def apply(executable: File) =
+    new Bindgen(executable)
 }

--- a/tools/src/main/scala/org/scalanative/bindgen/BindingOptions.scala
+++ b/tools/src/main/scala/org/scalanative/bindgen/BindingOptions.scala
@@ -1,0 +1,89 @@
+package org.scalanative.bindgen
+
+import java.io.File
+
+sealed trait BindingOptions {
+
+  /**
+   * Library to link with, e.g. -luv for libuv
+   */
+  def link(library: String): BindingOptions
+
+  /**
+   * Name of Scala object that contains bindings.
+   * Default is set to library name.
+   */
+  def name(name: String): BindingOptions
+
+  /**
+   * Package name of generated Scala file
+   */
+  def packageName(packageName: String): BindingOptions
+
+  /**
+   * Declarations will be removed if their names
+   * contain given prefix
+   */
+  def excludePrefix(prefix: String): BindingOptions
+
+  /**
+   * Additional arguments to append to the compiler command line
+   */
+  def extraArgs(args: String*): BindingOptions
+
+  /**
+   * Additional arguments to prepend to the compiler command line
+   */
+  def extraArgsBefore(args: String*): BindingOptions
+
+}
+
+object BindingOptions {
+  def apply(header: File): BindingOptions = {
+    require(header.exists(), s"Header does not exist: `$header`")
+    Impl(header = header)
+  }
+
+  private[bindgen] final case class Impl(header: File,
+                                         library: Option[String] = None,
+                                         name: Option[String] = None,
+                                         packageName: Option[String] = None,
+                                         excludePrefix: Option[String] = None,
+                                         extraArgs: Seq[String] = Seq.empty,
+                                         extraArgsBefore: Seq[String] =
+                                           Seq.empty)
+      extends BindingOptions {
+
+    override def link(library: String): BindingOptions = {
+      require(!library.isEmpty, "Library name must be non-empty")
+      copy(library = Option(library))
+    }
+
+    override def name(name: String): BindingOptions = {
+      require(!name.isEmpty, "Scala object name must be non-empty")
+      copy(name = Option(name))
+    }
+
+    override def packageName(packageName: String): BindingOptions = {
+      require(!packageName.isEmpty, "Package name must be non-empty")
+      copy(packageName = Option(packageName))
+    }
+
+    override def excludePrefix(prefix: String): BindingOptions = {
+      require(!prefix.isEmpty, "Exclude prefix must be non-empty")
+      copy(excludePrefix = Option(prefix))
+    }
+
+    override def extraArgs(args: String*): BindingOptions = {
+      require(args.forall(_.nonEmpty), "All extra-args must be non-empty")
+      copy(extraArgs = extraArgs ++ args)
+    }
+
+    override def extraArgsBefore(args: String*): BindingOptions = {
+      require(args.forall(_.nonEmpty),
+              "All extra-args-before must be non-empty")
+      copy(extraArgsBefore = extraArgsBefore ++ args)
+    }
+
+  }
+}

--- a/tools/src/main/scala/org/scalanative/bindgen/Bindings.scala
+++ b/tools/src/main/scala/org/scalanative/bindgen/Bindings.scala
@@ -3,11 +3,11 @@ package org.scalanative.bindgen
 import java.io.{File, PrintWriter}
 import scala.collection.immutable.Seq
 
-class Bindings(private val bindings: String, val errors: Seq[String]) {
+class Bindings(val name: String, val source: String, val errors: Seq[String]) {
   def writeToFile(file: File): Unit = {
     file.getParentFile.mkdirs()
     new PrintWriter(file) {
-      write(bindings)
+      write(source)
       close()
     }
   }


### PR DESCRIPTION
In order to ensure that the sbt plugin supports all options use the same
builder in the tools and sbt plugin projects. Separate out the options
into a new BindingOptions class to not expose unneeded methods in the
sbt plugin.