### PR TITLE
Do not generate TypeDef for enum

### DIFF
--- a/bindgen/TypeTranslator.h
+++ b/bindgen/TypeTranslator.h
@@ -35,7 +35,8 @@ class TypeTranslator {
      */
     std::map<std::string, std::string> typeMap;
 
-    std::shared_ptr<Type> translateRecordOrEnum(const clang::QualType &qtpe);
+    std::shared_ptr<Type>
+    translateNonAnonymousRecord(const clang::QualType &qtpe);
 
     std::shared_ptr<Type> translateRecord(const clang::QualType &qtpe);
 

--- a/bindgen/ir/Enum.cpp
+++ b/bindgen/ir/Enum.cpp
@@ -15,9 +15,8 @@ Enum::Enum(std::string name, std::string type,
 
 bool Enum::isAnonymous() const { return name.empty(); }
 
-std::shared_ptr<TypeDef> Enum::generateTypeDef() {
-    return std::make_shared<TypeDef>(getTypeName(), shared_from_this(),
-                                     nullptr);
+std::string Enum::getDefinition() {
+    return "  type " + getTypeAlias() + " = " + PrimitiveType::str() + "\n";
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Enum &e) {
@@ -51,7 +50,14 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Enum &e) {
 
 std::string Enum::getName() const { return name; }
 
-std::string Enum::getTypeName() const {
+std::string Enum::getTypeAlias() const {
     assert(!isAnonymous());
-    return "enum " + name;
+    return "enum_" + name;
+}
+
+std::string Enum::str(const LocationManager &locationManager) const {
+    if (locationManager.isImported(*location)) {
+        return locationManager.getImportedType(*location, getTypeAlias());
+    }
+    return getTypeAlias();
 }

--- a/bindgen/ir/Enum.h
+++ b/bindgen/ir/Enum.h
@@ -27,13 +27,15 @@ class Enum : public PrimitiveType, public LocatableType {
 
     bool isAnonymous() const;
 
-    std::shared_ptr<TypeDef> generateTypeDef();
+    std::string getDefinition();
 
     std::string getName() const;
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &s, const Enum &e);
 
-    std::string getTypeName() const;
+    std::string getTypeAlias() const;
+
+    std::string str(const LocationManager &locationManager) const override;
 
   private:
     std::string name; // might be empty

--- a/bindgen/ir/IR.h
+++ b/bindgen/ir/IR.h
@@ -29,12 +29,9 @@ class IR {
                                         std::shared_ptr<Type> type,
                                         std::shared_ptr<Location> location);
 
-    /**
-     * @return type alias for the enum
-     */
-    void addEnum(std::string name, const std::string &type,
-                 std::vector<Enumerator> enumerators,
-                 std::shared_ptr<Location> location);
+    std::shared_ptr<Enum> addEnum(std::string name, const std::string &type,
+                                  std::vector<Enumerator> enumerators,
+                                  std::shared_ptr<Location> location);
 
     std::shared_ptr<TypeDef>
     addStruct(std::string name, std::vector<std::shared_ptr<Field>> fields,
@@ -75,6 +72,8 @@ class IR {
     std::string getDefineForVar(const std::string &varName) const;
 
     std::shared_ptr<TypeDef> getTypeDefWithName(const std::string &name) const;
+
+    std::shared_ptr<Enum> getEnumWithName(const std::string &name) const;
 
   private:
     /**

--- a/bindgen/ir/TypeDef.h
+++ b/bindgen/ir/TypeDef.h
@@ -47,9 +47,12 @@ class TypeDef : public TypeAndName, public LocatableType {
 
     /**
      * @return location of the typedef is it is not generated otherwise
-     *         location of referenced type (struct, union or enum).
+     *         location of referenced record.
      */
     std::shared_ptr<Location> getLocation() const override;
+
+  private:
+    bool isGenerated() const;
 };
 
 #endif // SCALA_NATIVE_BINDGEN_TYPEDEF_H

--- a/bindgen/ir/types/PrimitiveType.cpp
+++ b/bindgen/ir/types/PrimitiveType.cpp
@@ -4,8 +4,10 @@
 
 PrimitiveType::PrimitiveType(std::string type) : type(std::move(type)) {}
 
+std::string PrimitiveType::str() const { return handleReservedWords(type); }
+
 std::string PrimitiveType::str(const LocationManager &locationManager) const {
-    return handleReservedWords(type);
+    return str();
 }
 
 std::string PrimitiveType::getType() const { return type; }

--- a/bindgen/ir/types/PrimitiveType.h
+++ b/bindgen/ir/types/PrimitiveType.h
@@ -17,6 +17,8 @@ class PrimitiveType : virtual public Type {
         const std::shared_ptr<const Type> &type, bool stopOnTypeDefs,
         std::vector<std::shared_ptr<const Type>> &visitedTypes) const override;
 
+    std::string str() const;
+
     std::string str(const LocationManager &locationManager) const override;
 
     bool operator==(const Type &other) const override;

--- a/bindgen/visitor/TreeVisitor.h
+++ b/bindgen/visitor/TreeVisitor.h
@@ -11,6 +11,8 @@ class TreeVisitor : public clang::RecursiveASTVisitor<TreeVisitor> {
     TypeTranslator typeTranslator;
     IR &ir;
 
+    bool isAliasForAnonymousEnum(clang::TypedefDecl *tpdef) const;
+
   public:
     TreeVisitor(clang::CompilerInstance *CI, IR &ir)
         : astContext(&(CI->getASTContext())), typeTranslator(astContext, ir),
@@ -20,7 +22,7 @@ class TreeVisitor : public clang::RecursiveASTVisitor<TreeVisitor> {
 
     virtual bool VisitFunctionDecl(clang::FunctionDecl *func);
     virtual bool VisitTypedefDecl(clang::TypedefDecl *tpdef);
-    virtual bool VisitEnumDecl(clang::EnumDecl *enumdecl);
+    virtual bool VisitEnumDecl(clang::EnumDecl *enumDecl);
     virtual bool VisitRecordDecl(clang::RecordDecl *record);
     virtual bool VisitVarDecl(clang::VarDecl *VD);
 };

--- a/tests/samples/IncludesHeader.scala
+++ b/tests/samples/IncludesHeader.scala
@@ -6,11 +6,11 @@ import scala.scalanative.native._
 @native.link("bindgentests")
 @native.extern
 object IncludesHeader {
+  type enum_semester = native.CUnsignedInt
   type size = native.CInt
   type struct_metadata = native.CStruct2[native.CUnsignedInt, native.CString]
   type metadata = struct_metadata
   type struct_document = native.CStruct1[metadata]
-  type enum_semester = native.CUnsignedInt
   type struct_courseInfo = native.CStruct2[native.CString, enum_semester]
   def getSize(d: native.Ptr[struct_document]): size = native.extern
 }

--- a/tests/samples/PrivateMembers.scala
+++ b/tests/samples/PrivateMembers.scala
@@ -6,14 +6,14 @@ import scala.scalanative.native._
 @native.link("bindgentests")
 @native.extern
 object PrivateMembers {
+  type enum___privateEnum = native.CUnsignedInt
+  type enum_enumWithPrivateMembers = native.CUnsignedInt
   type pid_t = native.CInt
   type __private_type = native.CInt
   type struct_structWithPrivateType = native.CStruct2[native.CInt, __private_type]
   type union___unionWithPrivateName = native.CArray[Byte, native.Nat._4]
   type struct_structWithPrivateStruct = native.CStruct1[native.Ptr[struct_structWithPrivateType]]
   type struct_normalStruct = native.CStruct1[native.CInt]
-  type enum___privateEnum = native.CUnsignedInt
-  type enum_enumWithPrivateMembers = native.CUnsignedInt
   type struct_privateStructWithTypedef = native.CStruct1[native.Ptr[__private_type]]
   type privateStructWithTypedef = struct_privateStructWithTypedef
   type privateStructWithTypedefPtr = native.Ptr[struct_privateStructWithTypedef]

--- a/tests/samples/Struct.scala
+++ b/tests/samples/Struct.scala
@@ -6,10 +6,11 @@ import scala.scalanative.native._
 @native.link("bindgentests")
 @native.extern
 object Struct {
+  type enum_pointIndex = native.CUnsignedInt
+  type enum_struct_op = native.CUnsignedInt
   type struct_point = native.CStruct2[native.CInt, native.CInt]
   type point = struct_point
   type struct_points = native.CStruct2[struct_point, point]
-  type enum_pointIndex = native.CUnsignedInt
   type point_s = native.Ptr[struct_point]
   type struct_bigStruct = native.CArray[Byte, native.Nat.Digit[native.Nat._1, native.Nat.Digit[native.Nat._1, native.Nat._2]]]
   type struct_anonymous_0 = native.CStruct2[native.CChar, native.CInt]
@@ -17,7 +18,6 @@ object Struct {
   type struct_packedStruct = native.CStruct1[native.CChar]
   type struct_bitFieldStruct = native.CArray[Byte, native.Nat._2]
   type struct_bitFieldOffsetDivByEight = native.CArray[Byte, native.Nat._4]
-  type enum_struct_op = native.CUnsignedInt
   def setPoints(points: native.Ptr[struct_points], x1: native.CInt, y1: native.CInt, x2: native.CInt, y2: native.CInt): Unit = native.extern
   def getPoint(points: native.Ptr[struct_points], pointIndex: enum_pointIndex): native.CInt = native.extern
   def createPoint(): native.Ptr[struct_point] = native.extern

--- a/tests/samples/Union.scala
+++ b/tests/samples/Union.scala
@@ -6,9 +6,9 @@ import scala.scalanative.native._
 @native.link("bindgentests")
 @native.extern
 object Union {
+  type enum_union_op = native.CUnsignedInt
   type struct_s = native.CStruct1[native.CInt]
   type union_values = native.CArray[Byte, native.Nat._8]
-  type enum_union_op = native.CUnsignedInt
   def union_get_sizeof(): native.CInt = native.extern
   def union_test_int(v: native.Ptr[union_values], op: enum_union_op, value: native.CInt): native.CInt = native.extern
   def union_test_long(v: native.Ptr[union_values], op: enum_union_op, value: native.CLong): native.CInt = native.extern


### PR DESCRIPTION
Generated typedefs are confusing.
The PR removes generated typedefs for enums.

If a field/parameter/variable has enum type, it references an `Enum` instance directly.

Also generated typedefs make #61 difficult to implement because enums and typedefs should be matched (in order to output enumerators right below enum type). It can be done by going through all typedefs, but it does not look good.