### PR TITLE
Move literal defines to main object

### DIFF
--- a/bindgen/ir/LiteralDefine.cpp
+++ b/bindgen/ir/LiteralDefine.cpp
@@ -6,7 +6,7 @@ LiteralDefine::LiteralDefine(std::string name, std::string literal,
 
 std::string
 LiteralDefine::getDefinition(const LocationManager &locationManager) const {
-    return "  val " + name + ": " + type->str(locationManager) + " = " +
+    return "    val " + name + ": " + type->str(locationManager) + " = " +
            literal + "\n";
 }
 

--- a/tests/samples/Cycles.scala
+++ b/tests/samples/Cycles.scala
@@ -3,8 +3,6 @@ package org.scalanative.bindgen.samples
 import scala.scalanative._
 import scala.scalanative.native._
 
-@native.link("bindgentests")
-@native.extern
 object Cycles {
   type struct_node = native.CStruct2[native.CInt, native.Ptr[Byte]]
   type struct_b = native.CStruct1[native.Ptr[native.Ptr[Byte]]]

--- a/tests/samples/LiteralDefine.scala
+++ b/tests/samples/LiteralDefine.scala
@@ -3,24 +3,27 @@ package org.scalanative.bindgen.samples
 import scala.scalanative._
 import scala.scalanative.native._
 
-object LiteralDefineDefines {
-  val STRING: native.CString = c"Hello, World!"
-  val LONG: native.CLong = 1000000000000L
-  val LONG_WITHOUT_ENDING: native.CLong = 1000000000000L
-  val LONG_LONG: native.CLongLong = 1000000000000L
-  val MAXIMUM_SIGNED_LONG: native.CLong = 9223372036854775807L
-  val MINIMUM_SIGNED_LONG: native.CLong = -9223372036854775808L
-  val FLOAT: native.CDouble = 5.6
-  val INT: native.CInt = 42
-  val MAXIMUM_INT: native.CInt = 2147483647
-  val NEW_INT: native.CInt = 42
-  val NEG_INT: native.CInt = -42
-  val SHOULD_BE_DEFINED: native.CString = c"Because INT is not equal to 0"
-  val OCTAL: native.CInt = 139
-  val HEXADECIMAL: native.CInt = 75
-  val EXPONENT: native.CDouble = 1e-10
-  val DOT_EXPONENT: native.CDouble = 0.01
-  val HEXADECIMAL_WITHOUT_RADIX: native.CDouble = 523264
-  val HEXADECIMAL_WITH_RADIX: native.CDouble = 7.5
-  val HEXADECIMAL_FRACTIONAL_WITH_RADIX: native.CDouble = 0.0355225
+object LiteralDefine {
+
+  object defines {
+    val STRING: native.CString = c"Hello, World!"
+    val LONG: native.CLong = 1000000000000L
+    val LONG_WITHOUT_ENDING: native.CLong = 1000000000000L
+    val LONG_LONG: native.CLongLong = 1000000000000L
+    val MAXIMUM_SIGNED_LONG: native.CLong = 9223372036854775807L
+    val MINIMUM_SIGNED_LONG: native.CLong = -9223372036854775808L
+    val FLOAT: native.CDouble = 5.6
+    val INT: native.CInt = 42
+    val MAXIMUM_INT: native.CInt = 2147483647
+    val NEW_INT: native.CInt = 42
+    val NEG_INT: native.CInt = -42
+    val SHOULD_BE_DEFINED: native.CString = c"Because INT is not equal to 0"
+    val OCTAL: native.CInt = 139
+    val HEXADECIMAL: native.CInt = 75
+    val EXPONENT: native.CDouble = 1e-10
+    val DOT_EXPONENT: native.CDouble = 0.01
+    val HEXADECIMAL_WITHOUT_RADIX: native.CDouble = 523264
+    val HEXADECIMAL_WITH_RADIX: native.CDouble = 7.5
+    val HEXADECIMAL_FRACTIONAL_WITH_RADIX: native.CDouble = 0.0355225
+  }
 }

--- a/tests/samples/NativeTypes.scala
+++ b/tests/samples/NativeTypes.scala
@@ -3,8 +3,6 @@ package org.scalanative.bindgen.samples
 import scala.scalanative._
 import scala.scalanative.native._
 
-@native.link("bindgentests")
-@native.extern
 object NativeTypes {
   type size_t = native.CUnsignedInt
   type ptrdiff_t = native.CUnsignedInt

--- a/tests/samples/Typedef.scala
+++ b/tests/samples/Typedef.scala
@@ -3,8 +3,6 @@ package org.scalanative.bindgen.samples
 import scala.scalanative._
 import scala.scalanative.native._
 
-@native.link("bindgentests")
-@native.extern
 object Typedef {
   type enum_days = native.CUnsignedInt
   object enum_days {

--- a/tests/src/test/scala/org/scalanative/bindgen/BindgenReportingSpec.scala
+++ b/tests/src/test/scala/org/scalanative/bindgen/BindgenReportingSpec.scala
@@ -79,6 +79,7 @@ class BindgenReportingSpec extends FunSpec {
       assertBindgenError(
         """union undefinedUnion;
           |typedef union undefinedUnion aliasForUndefinedUnion;
+          |void foo();
           |""".stripMargin,
         Seq(
           "Warning: type alias aliasForUndefinedUnion is skipped because it is an unused alias for incomplete type.")


### PR DESCRIPTION
Closes #61 

This commit also removes `@native.link("bindgentests")` `@native.extern` header for objects that do not have functions or extern variables